### PR TITLE
Reference health: scanner, CI workflow, and bib cleanup

### DIFF
--- a/.github/workflows/check-references.yml
+++ b/.github/workflows/check-references.yml
@@ -1,0 +1,172 @@
+name: Reference Health
+
+on:
+  schedule:
+    # 8th of Jan / Apr / Jul / Oct at 08:00 UTC — mid-month, reliably a weekday
+    - cron: "0 8 8 1,4,7,10 *"
+  push:
+    branches: [main]
+    paths:
+      - "assets/bibliography/papers.bib"
+  workflow_dispatch:
+    inputs:
+      recover:
+        description: "Query Wayback Machine for broken NERC URLs"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Job 1: run the scanner and upload the report as an artifact
+  # -------------------------------------------------------------------------
+  scan:
+    name: Scan references
+    runs-on: ubuntu-latest
+    outputs:
+      broken_count: ${{ steps.count.outputs.broken_count }}
+      artifact_url: ${{ steps.upload.outputs.artifact-url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install deps
+        run: pip install -r requirements-dev.txt
+
+      - name: Run reference scan
+        # Always use --recover (Wayback lookup) unless manually triggered with recover=false
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.recover }}" == "false" ]]; then
+            python pswiki.py check-refs
+          else
+            python pswiki.py check-refs --recover
+          fi
+          # The CLI exits 1 if broken links found; we capture that in the next step
+          # so we don't fail the workflow here — reporting job handles it
+        continue-on-error: true
+
+      - name: Extract broken count
+        id: count
+        run: |
+          BROKEN=$(python -c "
+          import json
+          r = json.load(open('database/build/reference_check.json'))
+          s = r['summary']
+          print(s.get('broken', 0) + s.get('server_error', 0))
+          ")
+          echo "broken_count=$BROKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Upload report artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: reference_check
+          path: database/build/reference_check.json
+          retention-days: 90
+
+  # -------------------------------------------------------------------------
+  # Job 2: update the persistent tracking issue
+  # -------------------------------------------------------------------------
+  report:
+    name: Update tracking issue
+    needs: scan
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BROKEN: ${{ needs.scan.outputs.broken_count }}
+      ARTIFACT_URL: ${{ needs.scan.outputs.artifact_url }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Download scan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: reference_check
+          path: database/build
+
+      - name: Render issue body
+        run: |
+          python database/pyscripts/render_ref_issue.py \
+            --report database/build/reference_check.json \
+            --artifact-url "$ARTIFACT_URL" \
+            --sha "${{ github.sha }}" \
+            --trigger "${{ github.event_name }}" \
+            --run-url "$RUN_URL" \
+            > /tmp/issue_body.md
+
+      - name: Find or create tracking issue
+        id: issue
+        run: |
+          # Search for the persistent tracker issue (open or closed)
+          ISSUE_NUMBER=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label ref-health \
+            --state all \
+            --json number,title \
+            --jq '.[] | select(.title == "[CI] Reference Health Tracker") | .number' \
+            | head -1)
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            ISSUE_NUMBER=$(gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "[CI] Reference Health Tracker" \
+              --body-file /tmp/issue_body.md \
+              --label ref-health \
+              --json number \
+              --jq '.number')
+            echo "Created issue #$ISSUE_NUMBER"
+          else
+            gh issue edit "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/issue_body.md
+            echo "Updated issue #$ISSUE_NUMBER"
+          fi
+
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Post run comment
+        run: |
+          SCAN_DATE=$(date -u +%Y-%m-%d)
+          if [ "$BROKEN" -gt 0 ]; then
+            STATUS_LINE="⚠️ **$BROKEN broken link(s)** detected — see tables above"
+          else
+            STATUS_LINE="✅ All references OK"
+          fi
+
+          SHA_SHORT="${{ github.sha }}"
+          SHA_SHORT="${SHA_SHORT:0:7}"
+
+          gh issue comment "${{ steps.issue.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --body "**Scan — ${SCAN_DATE}** · ${STATUS_LINE}
+          Trigger: \`${{ github.event_name }}\` · commit \`${SHA_SHORT}\` · [view run](${RUN_URL}) · [download report](${ARTIFACT_URL})"
+
+      - name: Open or close issue based on scan result
+        run: |
+          if [ "$BROKEN" -gt 0 ]; then
+            gh issue reopen "${{ steps.issue.outputs.issue_number }}" \
+              --repo "${{ github.repository }}" 2>/dev/null || true
+          else
+            gh issue close "${{ steps.issue.outputs.issue_number }}" \
+              --repo "${{ github.repository }}" \
+              --comment "All references OK as of $(date -u +%Y-%m-%d). Closing automatically." \
+              2>/dev/null || true
+          fi

--- a/_wiki/control-performance-standard-2.md
+++ b/_wiki/control-performance-standard-2.md
@@ -1,6 +1,6 @@
 ---
 title: Control Performance Standard 2
-description: CPS2. A standard intended to limit unscheduled flows.
+description: CPS2. Inactive. A standard intended to limit unscheduled flows.
 tags:
   - frequency-control
   - nerc
@@ -9,7 +9,7 @@ authors:
   - name: Jinning Wang
     url: https://jinningwang.github.io
 date: 2025-03-15
-lastmod: 2025-06-20
+lastmod: 2026-05-27
 ---
 
 ### Definition by NERC
@@ -26,7 +26,7 @@ Source: <d-cite key="nerc2015bal001"></d-cite> p22
 
 ### Calculation by NERC
 
-Source: <d-cite key="nerc2015bal0011"></d-cite> p3
+Source: <d-cite key="nerc2015bal0011"></d-cite>
 
 $$
 CPS2 = \left[ 1 - \frac{\text{Violations}_{\text{month}}}{\text{Total Periods}_{\text{month}} - \text{Unavailable Periods}_{\text{month}}} \right] \times 100

--- a/_wiki/operating-reserve.md
+++ b/_wiki/operating-reserve.md
@@ -13,7 +13,7 @@ authors:
   - name: Jinning Wang
     url: https://jinningwang.github.io
 date: 2025-03-15
-lastmod: 2025-06-22
+lastmod: 2026-05-27
 ---
 
 ### Definition by NERC
@@ -31,7 +31,7 @@ Source: <d-cite key="nerc2024glossary"></d-cite>
 
 ### Definition by NYISO
 
-Source: <d-cite key="nyiso2025ancillary"></d-cite> p41, Version 9.0
+Source: <d-cite key="nyiso2026ancillaryv10"></d-cite> p44, Version 10.0
 
 > Operating Reserve service provides backup generation and/or demand response in the event that the NYISO experiences a real-time power system Contingency requiring emergency corrective action. In order for the New York Control Area (NYCA) to respond in a timely fashion, the reserves must be available from qualified Resources located within the NYCA and within specific regions, as required by the NYSRC and other applicable reliability standards.
 

--- a/assets/bibliography/papers.bib
+++ b/assets/bibliography/papers.bib
@@ -136,11 +136,8 @@
   abbr = {Industry},
   author = {NERC},
   title = {Standard BAL-001-1 — Real Power Balancing Control Performance},
-  year = {2017},
-  month = {February},
-  day = {16},
-  url = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-1.pdf},
-  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. Superseded standard — BAL-001-2 remains active.}
+  url = {https://nercipedia.com/inactive-standards/bal-001/},
+  note = {Inactive standard; superseded by {BAL-001-2}. Archived via {NERCipedia} (LiveWire Compliance {LLC}).}
 }
 
 @online{nerc2015bal001,

--- a/assets/bibliography/papers.bib
+++ b/assets/bibliography/papers.bib
@@ -1079,6 +1079,17 @@
   year = {2025},
   month = {May},
   day = {1},
+  url = {https://www.nyiso.com/documents/20142/2923301/ancserv.pdf/df83ac75-c616-8c89-c664-99dfea06fe2f},
+  note = {URL unavailable as of 2026-05-27}
+}
+
+@online{nyiso2026ancillaryv10,
+  abbr = {Industry},
+  author = {NYISO},
+  title = {Manual 2: Ancillary Services Manual},
+  year = {2026},
+  month = {May},
+  day = {1},
   url = {https://www.nyiso.com/documents/20142/2923301/ancserv.pdf/df83ac75-c616-8c89-c664-99dfea06fe2f}
 }
 

--- a/assets/bibliography/papers.bib
+++ b/assets/bibliography/papers.bib
@@ -2,14 +2,12 @@
   abbr = {Industry},
 	title = {What Is a Digital Twin?},
 	url = {https://www.ibm.com/think/topics/what-is-a-digital-twin},
-  html = {https://www.ibm.com/think/topics/what-is-a-digital-twin},
 	author = {IBM},
 	urldate = {2025-03-15},
   year = {2021},
   month = {August},
   day = {5},
-  bibtex_show = {true},
-	abstract = {A digital twin is a virtual representation of an object or system designed to accurately reflect a physical object.},
+	abstract = {A digital twin is a virtual representation of an object or system designed to accurately reflect a physical object.}
 }
 
 @online{nerc2024ltra,
@@ -19,7 +17,6 @@
   year = {2024},
   month = {December},
   url = {https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/NERC_Long%20Term%20Reliability%20Assessment_2024.pdf},
-  pdf = {https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/NERC_Long%20Term%20Reliability%20Assessment_2024.pdf},
   abstract = {NERC is a not-for-profit international regulatory authority with the mission to assure the reliability of 
   the BPS in North America. NERC develops and enforces Reliability Standards; annually assesses 
   seasonal and long-term reliability; monitors the BPS through system awareness; and educates, trains, 
@@ -31,8 +28,7 @@
   FERC's regulations provides that “The Electric Reliability Organization shall conduct assessments of 
   the adequacy of the Bulk-Power System in North America and report its findings to the Commission, 
   the Secretary of Energy, each Regional Entity, and each Regional Advisory Body annually or more 
-  frequently if so ordered by the Commission.”},
-  bibtex_show = {true},
+  frequently if so ordered by the Commission.”}
 }
 
 @techreport{shah2024datacenter,
@@ -47,12 +43,11 @@
   day = {19},
   doi = {10.71468/P1WC7Q},
   dimensions = {false},
-  bibtex_show = {true},
   abstract = {The Energy Act of 2020 calls for the U.S. Department of Energy to make available to the public an update to Lawrence
   Berkeley National Laboratory's prior study entitled United States Data Center Energy Usage Report (2016). This report, designed
   to meet that Congressional request, estimates historical data center electricity consumption back to 2014, relying on previous
   studies and historical shipment data. This report also provides a scenario range of future demand out to 2028 based on new trends
-  and the most recent available data.},
+  and the most recent available data.}
 }
 
 @online{nerc2024incident,
@@ -63,8 +58,6 @@
   month = {January},
   day = {8},
   url = {https://www.nerc.com/pa/rrm/ea/Documents/Incident_Review_Large_Load_Loss.pdf},
-  pdf = {https://www.nerc.com/pa/rrm/ea/Documents/Incident_Review_Large_Load_Loss.pdf},
-  bibtex_show = {true},
   abstract = {A 230 kV transmission line fault led to customer-initiated simultaneous loss of approximately 1,500 MW of 
   voltage-sensitive load that was not anticipated by the BES operators. The electric grid has not historically
   experienced simultaneous load losses of this magnitude in response to a fault on the system, which has 
@@ -75,7 +68,7 @@
   concern. The voltage also did not rise to levels that posed a reliability risk, but operators did have to take 
   action to reduce the voltage to within normal operating levels. However, as the potential for this type of 
   load loss increases, the risk for frequency and voltage issues also increases. Operators and planners should 
-  be aware of this reliability risk and ensure that these load losses do not reach intolerable levels.},
+  be aware of this reliability risk and ensure that these load losses do not reach intolerable levels.}
 }
 
 @online{howland2024ferc,
@@ -85,10 +78,8 @@
   year = {2024},
   month = {November},
   url = {https://www.utilitydive.com/news/ferc-interconnection-isa-talen-amazon-data-center-susquehanna-exelon/731841/},
-  html = {https://www.utilitydive.com/news/ferc-interconnection-isa-talen-amazon-data-center-susquehanna-exelon/731841/},
-  bibtex_show = {true},
   abstract = {Chairman Willie Phillips dissented from the decision on the “first of its kind” co-location proposal,
-  saying it could harm national security and grid reliability.},
+  saying it could harm national security and grid reliability.}
 }
 
 @article{gomez2019datacenter,
@@ -102,7 +93,6 @@
   pages = {1611-1621},
   doi = {10.1109/TSG.2021.3125275},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Over the past decade, there has been a global growth in datacenter capacity, power consumption and the associated
   costs. Accurate mapping of datacenter resource usage (CPU, RAM, etc.) and hardware configurations (servers, accelerators, etc.)
   to its power consumption is necessary for efficient long-term infrastructure planning and real-time compute load management.
@@ -113,7 +103,7 @@
   types across Google fleet. A multi-year validation of the deployed models demonstrate that they can predict power with less
   than 5% Mean Absolute Percent Error (MAPE) for more than 95% diverse PDUs across Google fleet. This performance matches the best
   reported accuracies coming from studies that focus on specific workload types, hardware platforms and, typically, more complex
-  statistical models.},
+  statistical models.}
 }
 
 @online{nerc2024glossary,
@@ -124,10 +114,8 @@
   month = {February},
   day = {26},
   url = {https://www.nerc.com/pa/Stand/Glossary%20of%20Terms/Glossary_of_Terms.pdf},
-  pdf = {https://www.nerc.com/pa/Stand/Glossary%20of%20Terms/Glossary_of_Terms.pdf},
-  bibtex_show = {true},
   abstract = {This Glossary lists each term that was defined for use in one or more of NERC's continent-wide or Regional 
-  Reliability Standards and adopted by the NERC Board of Trustees from February 8, 2005 through February 26, 2025},
+  Reliability Standards and adopted by the NERC Board of Trustees from February 8, 2005 through February 26, 2025}
 }
 
 @online{nerc2021balancing,
@@ -138,11 +126,10 @@
   month = {May},
   day = {11},
   url = {https://www.nerc.com/comm/RSTC_Reliability_Guidelines/Reference_Document_NERC_Balancing_and_Frequency_Control.pdf},
-  pdf = {https://www.nerc.com/comm/RSTC_Reliability_Guidelines/Reference_Document_NERC_Balancing_and_Frequency_Control.pdf},
   abstract = {The NERC Resources Subcommittee (RS) drafted this reference document at the request of the NERC Operating 
   Committee as part of a series on operating and planning reliability concepts. The document covers balancing and 
   frequency control concepts, issues, and recommendations. Send questions and suggestions for changes and 
-  additions to balancing@nerc.com.},
+  additions to balancing@nerc.com.}
 }
 
 @online{nerc2015bal0011,
@@ -153,8 +140,7 @@
   month = {February},
   day = {16},
   url = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-1.pdf},
-  pdf = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-1.pdf},
-  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. Superseded standard — BAL-001-2 remains active.},
+  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. Superseded standard — BAL-001-2 remains active.}
 }
 
 @online{nerc2015bal001,
@@ -164,8 +150,7 @@
   year = {2015},
   month = {April},
   day = {23},
-  url = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-2.pdf},
-  pdf = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-2.pdf},
+  url = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-2.pdf}
 }
 
 @online{nerc2015bal001background,
@@ -176,10 +161,9 @@
   month = {July},
   day = {16},
   url = {https://www.nerc.com/pa/Stand/Project%202010141%20%20Phase%201%20of%20Balancing%20Authority%20Re/BAL-001-2_Background_%20Document-Clean-20130701.pdf#search=Real%20Power%20%20Balancing%20Control%20%20Performance%20Standard%20Background},
-  pdf = {https://www.nerc.com/pa/Stand/Project%202010141%20%20Phase%201%20of%20Balancing%20Authority%20Re/BAL-001-2_Background_%20Document-Clean-20130701.pdf#search=Real%20Power%20%20Balancing%20Control%20%20Performance%20Standard%20Background},
   abstract = {This document provides background on the development, testing, and implementation of BAL-001-2 - Real Power
   Balancing Control Standard. The intent is to explain the rationale and considerations for the requirements and their
-  associated compliance information.},
+  associated compliance information.}
 }
 
 @article{kundur2004stability,
@@ -194,14 +178,13 @@
   month = {August},
   doi = {10.1109/TPWRS.2004.825981},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The problem of defining and classifying power system stability has been addressed by several previous CIGRE and IEEE Task
   Force reports. These earlier efforts, however, do not completely reflect current industry needs, experiences and understanding. In
   particular, the definitions are not precise and the classifications do not encompass all practical instability scenarios. This report
   developed by a Task Force, set up jointly by the CIGRE Study Committee 38 and the IEEE Power System Dynamic Performance Committee,
   addresses the issue of stability definition and classification in power systems from a fundamental viewpoint and closely examines the
   practical ramifications. The report aims to define power system stability more precisely, provide a systematic basis for its
-  classification, and discuss linkages to related issues such as power system reliability and security.},
+  classification, and discuss linkages to related issues such as power system reliability and security.}
 }
 
 @article{hatziargyriou2021stability,
@@ -216,13 +199,12 @@
   month = {July},
   doi = {10.1109/TPWRS.2020.3041774},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Since the publication of the original paper on power system stability definitions in 2004, the dynamic behavior of power
   systems has gradually changed due to the increasing penetration of converter interfaced generation technologies, loads, and transmission
   devices. In recognition of this change, a Task Force was established in 2016 to re-examine and extend, where appropriate, the classic
   definitions and classifications of the basic stability terms to incorporate the effects of fast-response power electronic devices. This
   paper based on an IEEE PES report summarizes the major results of the work of the Task Force and presents extended definitions and
-  classification of power system stability.},
+  classification of power system stability.}
 }
 
 @online{nerc2021reserve,
@@ -232,8 +214,6 @@
   year = {2021},
   month = {June},
   url = {https://www.nerc.com/comm/RSTC_Reliability_Guidelines/Reliability_Guideline_Template_Operating_Reserve_Management_Version_3.pdf},
-  pdf = {https://www.nerc.com/comm/RSTC_Reliability_Guidelines/Reliability_Guideline_Template_Operating_Reserve_Management_Version_3.pdf},
-  bibtex_show = {true},
   abstract = {It is in the public interest for NERC to develop guidelines that are useful for maintaining and enhancing the
   reliability of the Bulk Electric System (BES). The subgroups of the Reliability and Security Technical 
   Committee (RSTC)—in accordance with the RSTC charter1 are authorized by the NERC Board of Trustees to 
@@ -245,7 +225,7 @@
   provide binding norms or create parameters by which compliance to NERC Reliability Standards are 
   monitored or enforced. While the incorporation, of guideline practices, is strictly voluntary, reviewing, 
   revising, or developing a program using these practices is highly encouraged to promote and achieve 
-  appropriate BES reliability},
+  appropriate BES reliability}
 }
 
 @online{ferc2020glossary,
@@ -255,9 +235,7 @@
   year = {2020},
   month = {August},
   day = {31},
-  url = {https://www.ferc.gov/industries-data/market-assessments/overview/glossary},
-  html = {https://www.ferc.gov/industries-data/market-assessments/overview/glossary},
-  bibtex_show = {true},
+  url = {https://www.ferc.gov/industries-data/market-assessments/overview/glossary}
 }
 
 @online{ferc2020public,
@@ -268,7 +246,6 @@
   month = {August},
   day = {31},
   url = {https://www.ferc.gov/industries-data/resources/public-reference-room/ferc-glossary},
-  bibtex_show = {true},
   abstract = {The Division of Energy Market Assessments, in the Office of Energy Policy and Innovation, serves the public by overseeing
   the nation's natural gas and electric power markets and related energy and financial markets. Market Assessments conducts
   daily assessments of these markets and reports its findings and recommendations to the Commission and the public. This
@@ -276,7 +253,7 @@
   identifies emerging trends in those markets. The content will be updated and additional information will be added as it becomes available.
   FERC provides market assessments of interstate electricity and natural gas markets and publishes analyses and reports
   including the Winter Energy Market Assessment, the Summer Market and Reliability Assessment, the State of the Markets Report,
-  and the Energy Primer.},
+  and the Energy Primer.}
 }
 
 @online{nerc2011ancillary,
@@ -286,9 +263,7 @@
   year = {2011},
   month = {March},
   url = {http://web.archive.org/web/20220605060008/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF2-3.pdf},
-  pdf = {http://web.archive.org/web/20220605060008/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF2-3.pdf},
-  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2022-06-05).},
-  bibtex_show = {true},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2022-06-05).}
 }
 
 @online{nerc2013probabilistic,
@@ -298,8 +273,6 @@
   year = {2013},
   month = {June},
   url = {https://www.nerc.com/comm/PC/PAWG%20DL/NERC_2012_Probabilistic_Assessment_Final.pdf},
-  pdf = {https://www.nerc.com/comm/PC/PAWG%20DL/NERC_2012_Probabilistic_Assessment_Final.pdf},
-  bibtex_show = {true},
   abstract = {The 2012 Probabilistic Assessment Report (2012 ProbA) is designed to complement the 2012 LTRA by providing additional 
   probabilistic statistics of EUE and LOLH. This assessment includes the results of each assessment area's third and fifth year 
   forecasts (i.e., 2014 and 2016 results) from the 2012 LTRA. The assessment areas represented are shown in Figure 1. For the 
@@ -323,7 +296,7 @@
   With the approval of the pilot report, the Planning Committee concluded that the probabilistic assessment complemented 
   and enhanced the efforts of the Reliability Assessment Subcommittee (RAS) and should be a biennial report with the 
   participation of all assessment areas across the whole NERC footprint. This is the first such report in the series of 
-  probabilistic assessments covering all of the NERC Assessment Areas.},
+  probabilistic assessments covering all of the NERC Assessment Areas.}
 }
 
 @online{nerc2020sri,
@@ -332,9 +305,7 @@
   title = {Severity Risk Index Enhancements},
   year = {2020},
   month = {October},
-  url = {https://www.nerc.com/comm/PC/Performance%20Analysis%20Subcommittee%20PAS%202013/SRI_Enhancements_October_2020.pdf},
-  pdf = {https://www.nerc.com/comm/PC/Performance%20Analysis%20Subcommittee%20PAS%202013/SRI_Enhancements_October_2020.pdf},
-  bibtex_show = {true},
+  url = {https://www.nerc.com/comm/PC/Performance%20Analysis%20Subcommittee%20PAS%202013/SRI_Enhancements_October_2020.pdf}
 }
 
 @online{nerc2024sor,
@@ -344,14 +315,12 @@
   year = {2024},
   month = {June},
   url = {https://www.nerc.com/pa/RAPA/PA/Performance%20Analysis%20DL/NERC_SOR_2024_Technical_Assessment.pdf},
-  pdf = {https://www.nerc.com/pa/RAPA/PA/Performance%20Analysis%20DL/NERC_SOR_2024_Technical_Assessment.pdf},
-  bibtex_show = {true},
   abstract = {The State of Reliability (SOR) report seeks to inform regulators, policymakers, and industry leaders on the most 
   significant reliability risks facing the BPS and describe the actions that the ERO Enterprise has taken and will take to 
   address them. This year's SOR report is comprised of two publications: this 2024 SOR Technical Assessment, which 
   provides NERC's comprehensive annual technical review of BPS reliability for the 2023 operating (calendar) year, and 
   the 2024 SOR Overview, which is a high-level summary of the Technical Assessment, summarized by important 
-  findings.},
+  findings.}
 }
 
 @online{nerc2018resilience,
@@ -361,9 +330,7 @@
   year = {2018},
   month = {November},
   day = {8},
-  bibtex_show = {true},
   url = {https://www.nerc.com/comm/RISC/Related%20Files%20DL/RISC%20Resilience%20Report_Approved_RISC_Committee_November_8_2018_Board_Accepted.pdf},
-  pdf = {https://www.nerc.com/comm/RISC/Related%20Files%20DL/RISC%20Resilience%20Report_Approved_RISC_Committee_November_8_2018_Board_Accepted.pdf},
   abstract = {In August 2017, the Department of Energy (DOE) issued a Staff Report to the Secretary on Electricity Markets and 
   Reliability (DOE Grid Report) regarding reliability and resilience in light of the changing energy environment.
   One recommendation in the DOE Grid Report stated that NERC should consider adding resilience to its mission and 
@@ -389,7 +356,7 @@
   In particular, NERC must develop and enforce Reliability Standards for Reliable Operation on the BES of the BPS and 
   conduct periodic assessments of the reliability and adequacy of the BPS in North America. For more than 50 years, 
   “reliability” for the BPS has been defined to consist of two fundamental and aspirational concepts: adequacy and
-  operating reliability.},
+  operating reliability.}
 }
 
 @article{chiu2020resilience,
@@ -402,7 +369,6 @@
   year = {2020},
   month = {October},
   day = {29},
-  bibtex_show = {true},
   abstract = {The resilience of the electric grid is the foundational building block for our decarbonized clean energy future.
   While the concept of resiliency is not new, its application to the electric grid is not as straightforward due to the lack
   of a consistent definition of resilience or a mature set of metrics by which resilience or its application can be measured.
@@ -414,7 +380,7 @@
   including some of the more common practices and use cases to increase system resilience, enhance broader preparedness, and to
   combat the impacts of the various external impacts to the electric power grid. Those use cases include Southern California Edison,
   Con Edison, Entergy, Florida utilities, San Diego Gas & Electric, ComEd, Austin Energy, as well as transmission and distribution
-  system hardening practices, wild-fire risk mitigation lessons learned from California, and NERC reliability and cyber-security standards.},
+  system hardening practices, wild-fire risk mitigation lessons learned from California, and NERC reliability and cyber-security standards.}
 }
 
 @online{nerc2024tpl,
@@ -423,25 +389,22 @@
   title = {Technical Rationale and Justification for TPL-008-1},
   year = {2024},
   month = {March},
-  bibtex_show = {true},
   url = {https://www.nerc.com/pa/Stand/Project202307ModtoTPL00151TransSystPlanPerfReqExWe/2023-07_TPL-008-1%20Technical%20Rationale_032024.pdf},
-  pdf = {https://www.nerc.com/pa/Stand/Project202307ModtoTPL00151TransSystPlanPerfReqExWe/2023-07_TPL-008-1%20Technical%20Rationale_032024.pdf},
   abstract = {This document explains the technical rationale and justification for the proposed Reliability Standard TPL-008-1. It 
   provides stakeholders and the ERO Enterprise with an understanding of the technology and technical requirements 
   in the Reliability Standard. This Technical Rationale and Justification for TPL-008-1 is not a Reliability Standard and 
-  should not be considered mandatory and enforceable.},
+  should not be considered mandatory and enforceable.}
 }
 
 @online{matpowerv71,
   abbr = {Industry},
   author = {Ray D. Zimmerman and Carlos E. Murillo-Sanchez},
   title = {MATPOWER User's Manual, Version 7.1},
-  url = {https://matpower.org/doc-original/manuals/},
-  pdf = {https://matpower.org/docs/MATPOWER-manual-7.1.pdf},
-  bibtex_show = {true},
+  url = {https://matpower.org/docs/MATPOWER-manual-7.1.pdf},
+  note = {MATPOWER documentations: \url{https://matpower.org/documentation/}},
   year = {2020},
   month = {October},
-  day = {8},
+  day = {8}
 }
 
 @online{pjm2023transmission,
@@ -449,11 +412,9 @@
   author = {PJM},
   title = {Transmission Zones Map},
   url = {https://www.pjm.com/-/media/DotCom/about-pjm/pjm-zones.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/about-pjm/pjm-zones.pdf},
-  bibtex_show = {true},
   year = {2023},
   month = {May},
-  day = {11},
+  day = {11}
 }
 
 @online{nerc2013terminology,
@@ -463,9 +424,7 @@
   year = {2013},
   month = {August},
   url = {http://web.archive.org/web/20250401183750/https://www.nerc.com/aboutnerc/documents/terms%20aug13.pdf},
-  pdf = {http://web.archive.org/web/20250401183750/https://www.nerc.com/aboutnerc/documents/terms%20aug13.pdf},
-  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-04-01).},
-  bibtex_show = {true},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-04-01).}
 }
 
 @online{nerc2023inverter,
@@ -474,9 +433,7 @@
   title = {An Introduction to Inverter-based Resources on the Bulk Power System},
   year = {2023},
   month = {June},
-  url = {https://www.nerc.com/pa/Documents/2023_NERC_Guide_Inverter-Based-Resources.pdf},
-  pdf = {https://www.nerc.com/pa/Documents/2023_NERC_Guide_Inverter-Based-Resources.pdf},
-  bibtex_show = {true},
+  url = {https://www.nerc.com/pa/Documents/2023_NERC_Guide_Inverter-Based-Resources.pdf}
 }
 
 @online{nerc2010flexible,
@@ -486,9 +443,7 @@
   year = {2010},
   month = {November},
   url = {http://web.archive.org/web/20250615132555/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF_Task_1_5_Final.pdf},
-  pdf = {http://web.archive.org/web/20250615132555/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF_Task_1_5_Final.pdf},
-  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-06-15).},
-  bibtex_show = {true},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-06-15).}
 }
 
 @online{nyiso2024power,
@@ -497,9 +452,7 @@
   title = {Power Trends 2024},
   year = {2024},
   month = {November},
-  url = {https://www.nyiso.com/documents/20142/2223020/2024-Power-Trends.pdf/31ec9a11-21f2-0b47-677d-f4a498a32978?t=1717677687961},
-  pdf = {https://www.nyiso.com/documents/20142/2223020/2024-Power-Trends.pdf/31ec9a11-21f2-0b47-677d-f4a498a32978?t=1717677687961},
-  bibtex_show = {true},
+  url = {https://www.nyiso.com/documents/20142/2223020/2024-Power-Trends.pdf/31ec9a11-21f2-0b47-677d-f4a498a32978?t=1717677687961}
 }
 
 @online{nyiso2024clean,
@@ -508,9 +461,7 @@
   title = {How Competitive Electricity Markets Power New York State's Clean Energy Goals},
   year = {2024},
   month = {March},
-  url = {https://www.nyiso.com/documents/20142/2224547/How-Electricity-Markets-Power-NYS-Clean-Energy-Goals.pdf/819ee0e6-989f-b28e-e3e0-8967bbd4a735},
-  pdf = {https://www.nyiso.com/documents/20142/2224547/How-Electricity-Markets-Power-NYS-Clean-Energy-Goals.pdf/819ee0e6-989f-b28e-e3e0-8967bbd4a735},
-  bibtex_show = {true},
+  url = {https://www.nyiso.com/documents/20142/2224547/How-Electricity-Markets-Power-NYS-Clean-Energy-Goals.pdf/819ee0e6-989f-b28e-e3e0-8967bbd4a735}
 }
 
 @techreport{anderson2023cim,
@@ -525,7 +476,6 @@
   month = {03},
   day = {01},
   dimensions = {false},
-  bibtex_show = {true},
   abstract = {A key issue in creating the next generation of energy management system (EMS) and advanced distribution management
   system (ADMS) platforms will be the ability to represent and exchange power system network model data in a consistent manner. To
   this end, the Common Information Model (CIM) stands out as the only standardized vocabulary (or ontology) for defining power system
@@ -537,7 +487,7 @@
   system engineers and application developers not familiar with semantic modeling to start using the CIM for modeling, simulation,
   optimization, and development of advanced power applications. The key classes needed for defining power system topology and equipment
   are explained systematically. Key focus areas include modeling of lines, transformers, generators, switching equipment, loads, and
-  distributed energy resources (DERs).},
+  distributed energy resources (DERs).}
 }
 
 @techreport{epri2021cim,
@@ -551,8 +501,6 @@
   address = {Palo Alto, CA},
   note = {Technical Update, July 2021},
   url = {https://www.epri.com/research/products/3002021840},
-  html = {https://www.epri.com/research/products/3002021840},
-  bibtex_show = {true},
   abstract = {Common Information Model Primer helps readers understand how the Common Information Model (CIM) is used at electric utilities.
   The primer explains how the CIM originated and was developed through the years, with the support of working groups of Technical Committee
   57 of the International Electrotechnical Commission.
@@ -573,9 +521,7 @@
   month = {December},
   day = {12},
   url = {http://web.archive.org/web/20220602142235/https://site.ieee.org/pes-enews/2015/12/10/a-brief-history-the-common-information-model/},
-  html = {http://web.archive.org/web/20220602142235/https://site.ieee.org/pes-enews/2015/12/10/a-brief-history-the-common-information-model/},
-  note = {Original IEEE PES eNews URL permanently gone (HTTP 410) as of 2026-05-27; archived via Wayback Machine (snapshot 2022-06-02).},
-  bibtex_show = {true},
+  note = {Original IEEE PES eNews URL permanently gone (HTTP 410) as of 2026-05-27; archived via Wayback Machine (snapshot 2022-06-02).}
 }
 
 @article{ieee2010comfede,
@@ -588,7 +534,6 @@
   pages = {1-72},
   doi = {10.1109/IEEESTD.2010.5638582},
   dimensions = {false},
-  bibtex_show = {true},
   abstract = {This standard defines a common format for the data files needed for the exchange of various types of
   power network events in order to facilitate event data integration and analysis from multiple data sources and from
   different vendor devices. The flexibility provided by digital devices in recording network fault event data in the
@@ -597,7 +542,7 @@
   and related protection schemes during fault and disturbance conditions. Since each source of data may use a different
   proprietary format, a common data format is necessary to facilitate the exchange of such data between applications.
   This will facilitate the use of proprietary data in diverse applications and allow users of one proprietary system
-  to use digital data from other systems.},
+  to use digital data from other systems.}
 }
 
 @article{ieee1999comtrade,
@@ -610,12 +555,11 @@
   pages = {1-55},
   doi = {10.1109/IEEESTD.1999.90571},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Reaffirmed 2005. A common format for data files and exchange medium used for the interchange of various
   types of fault, test, or simulation data for electrical power systems is defined. Sources of transient data are described,
   and the case of diskettes as an exchange medium is recommended. Issues of sampling rates, filters, and sample rate
   conversions for transient data being exchanged are discussed. Files for data exchange are specified, as is the organization
-  of the data. A sample file is given.},
+  of the data. A sample file is given.}
 }
 
 @article{ieee1973loadflow,
@@ -631,11 +575,10 @@
   doi = {10.1109/TPAS.1973.293571},
   dimensions = {true},
   url = {https://ieeexplore.ieee.org/document/4075293},
-  bibtex_show = {true},
   abstract = {This paper presents a Common Format for the exchange of solved load flow cases. This format is presently being
   used throughout most of the eastern and north central United States and parts of Canada. By publishing through the national
   organization, it is intended that a common reference be established and maintained for those who wish to use the format. The
-  paper presents a detailed description of the format as well as procedures for making revisions and additions.},
+  paper presents a detailed description of the format as well as procedures for making revisions and additions.}
 }
 
 @article{ieee2018std1547,
@@ -647,13 +590,12 @@
   day = {06},
   pages = {1-138},
   doi = {10.1109/IEEESTD.2018.8332112},
-  bibtex_show = {true},
   dimensions = {false},
   url = {https://ieeexplore.ieee.org/document/8332112},
   abstract = {This standard provides interconnection and interoperability technical and test specifications 
   and requirements for distributed energy resources (DERs). Additionally, several annexes are included 
   in this standard that provide additional material for informative purposes, but are not required to be 
-  used in conjunction with this standard.},
+  used in conjunction with this standard.}
 }
 
 @article{xue1988eeca,
@@ -669,7 +611,6 @@
   pages={400-412},
   doi={10.1109/59.192890},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {A method for online transient stability assessment of large power systems is proposed. It consists of:
   replacing the multimachine system by a two-machine dynamic equivalent, further amenable to a one-machine-infinite-bus
   system; reducing the stability problem to a sole algebraic equation, devised from the equal area criterion, or
@@ -677,7 +618,7 @@
   A technique for system admittance matrix reduction is developed that proves efficient, especially for large systems
   and multiple-contingency evaluation. The method's main appeal is rapidity: it is about one order of magnitude faster than
   the most efficient direct criterion. Other attractive features are flexibility and ability to encompass various simulation
-  conditions. Extensions to online sensitivity analysis and control are suggested.},
+  conditions. Extensions to online sensitivity analysis and control are suggested.}
 }
 
 @book{kundur1994Power,
@@ -689,7 +630,6 @@
 	title = {Power System Stability and Control},
 	author = {Kundur, Prabha},
 	year = {1994},
-  bibtex_show = {true},
   abstract = {This book is concerned with understanding, modelling, analyzing, and mitigating power system stability and control
   problems. Such problems constitute very important considerations ni the planning, design, and operation of modern power systems.
   The complexity of power systems is continually increasing because of the growth in interconnections and use of new technologies.
@@ -698,7 +638,7 @@
   control aids to enhance system security, facilitate economic design, and provide greater flexibility of system operation.
   In addition, advances in computer technology, numerical analysis, control theory, and equipment modelling have contributed to
   the development of improved analytical tools and better system-design procedures. The primary motivation for writing this book
-  has been to describe these new developments and to provide a comprehensive treatment of the subject.},
+  has been to describe these new developments and to provide a comprehensive treatment of the subject.}
 }
 
 @article{dahl1935stability,
@@ -713,10 +653,9 @@
   pages = {185-188},
   doi = {10.1109/T-AIEE.1935.5056954},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The transient tability of the general 2-machine system is considered in this paper. Introduction of an equivalent
   system with concentrated inertia at one end is shown to facilitate the direct application of the equal area method of
-  analysis to the general 2-machine system. Heretofore the equal area method has been confined to certain special 2-machine systems.},
+  analysis to the general 2-machine system. Heretofore the equal area method has been confined to certain special 2-machine systems.}
 }
 
 @article{rao1972dynamic,
@@ -731,12 +670,11 @@
   pages = {118-122},
   doi = {10.1109/TPAS.1972.293320},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {A method of dynamic aggregation is introduced to define power system transient stability indices based on the
   previously used concepts of potential and kinetic energies. The indices are easier to compute and less conservative than those
   introduced by other authors. They reflect quantitatively the seriousness of the system instability threat created by actual or
   postulated faults. They are thus useful for purposes of on-line system security monitoring and interpretation of transient
-  stability studies.},
+  stability studies.}
 }
 
 @article{teichgraeber1970stability,
@@ -750,11 +688,10 @@
   pages = {233-239},
   doi = {10.1109/TPAS.1970.292585},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {A new measure of the relative transient stability of a multimachine power system based on the Lyapunov stability
   theory is introduced. Techniques of sensitivity analysis are used to determine numerically the influence of variations or errors
   in the estimation of the system parameters on the transient stability of a power system. In particular, data is presented for an
-  application of these ideas to a one machine infinite bus system.},
+  application of these ideas to a one machine infinite bus system.}
 }
 
 @article{byerly1971transfer,
@@ -769,11 +706,10 @@
   pages = {993-999},
   doi = {10.1109/TPAS.1971.292840},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {A method is presented for analyzing the results of stability calculations using generator transfer admittances to
   calculate power flows between generators. It is shown that the equations for power flow from any generator to all other generators
   can be used to define an equivalent system bus unique to that generator. Functions which indicate the capability of a generator
-  to maintain synchronism are presented with illustrations of their application.},
+  to maintain synchronism are presented with illustrations of their application.}
 }
 
 @online{pjm2024m3v67,
@@ -784,11 +720,9 @@
   month = {November},
   day = {11},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v67-transmission-operations-11-21-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v67-transmission-operations-11-21-2024.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Transmission Operations is one of a series of manuals within the
   Transmission set. This manual focuses on specific transmission conditions and procedures for
-  the operation of the Bulk Electric System and Designated Transmission Facilities.},
+  the operation of the Bulk Electric System and Designated Transmission Facilities.}
 }
 
 @online{pjm2025m3v68,
@@ -799,11 +733,9 @@
   day = {21},
   title = {Manuals M-3: Transmission Operations (Revision 68)},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v68-transmission-operations-05-21-2025.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v68-transmission-operations-05-21-2025.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Transmission Operations is one of a series of manuals within the
   Transmission set. This manual focuses on specific transmission conditions and procedures for
-  the operation of the Bulk Electric System and Designated Transmission Facilities.},
+  the operation of the Bulk Electric System and Designated Transmission Facilities.}
 }
 
 @online{pjm2025m3v69,
@@ -814,11 +746,9 @@
   day = {20},
   title = {Manuals M-3: Transmission Operations (Revision 69)},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v69-transmission-operations-11-20-2025.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v69-transmission-operations-11-20-2025.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Transmission Operations is one of a series of manuals within the
   Transmission set. This manual focuses on specific transmission conditions and procedures for
-  the operation of the Bulk Electric System and Designated Transmission Facilities.},
+  the operation of the Bulk Electric System and Designated Transmission Facilities.}
 }
 
 @online{pjm2024m3a,
@@ -829,11 +759,9 @@
   month = {October},
   day = {30},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03a/m03av25-energy-management-system-model-updates-and-quality-assurance-10-30-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03a/m03av25-energy-management-system-model-updates-and-quality-assurance-10-30-2024.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Energy Management System Model Updates and Quality Assurance is one
   of a series of manuals within the Transmission set. This manual focuses on specific process
-  and procedures for the updating and verifying the PJM EMS model.},
+  and procedures for the updating and verifying the PJM EMS model.}
 }
 
 @online{pjm2024m10,
@@ -844,10 +772,8 @@
   month = {November},
   day = {21},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m10/m10v45-pre-scheduling-operations-11-21-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m10/m10v45-pre-scheduling-operations-11-21-2024.pdf},
-  bibtex_show = {true},
   abstract = {This manual focuses on PJM and PJM Member pre-scheduling activities that set the stage for the
-  scheduling and dispatching phases of the PJM RTO operation.},
+  scheduling and dispatching phases of the PJM RTO operation.}
 }
 
 @online{pjm2024m11,
@@ -858,12 +784,10 @@
   month = {December},
   day = {17},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m11/m11v133-energy-and-ancillary-services-market-operations-12-17-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m11/m11v133-energy-and-ancillary-services-market-operations-12-17-2024.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Energy & Ancillary Services Market Operations is one of a series of
   manuals within the PJM Energy Market Manuals. This manual focuses on the Day-ahead and
   Real-time scheduling activities that are performed by the PJM staff and the PJM Members. The
-  manual describes the rules and procedures that are followed to schedule resources.},
+  manual describes the rules and procedures that are followed to schedule resources.}
 }
 
 @online{pjm2025m11,
@@ -874,12 +798,10 @@
   month = {April},
   day = {23},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m11/m11v134-energy-and-ancillary-services-market-operations-04-23-2025.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m11/m11v134-energy-and-ancillary-services-market-operations-04-23-2025.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Energy & Ancillary Services Market Operations is one of a series of
   manuals within the PJM Energy Market Manuals. This manual focuses on the Day-ahead and
   Real-time scheduling activities that are performed by the PJM staff and the PJM Members. The
-  manual describes the rules and procedures that are followed to schedule resources.},
+  manual describes the rules and procedures that are followed to schedule resources.}
 }
 
 @online{pjm2024m12,
@@ -890,12 +812,10 @@
   month = {December},
   day = {17},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m12/m12v54-balancing-operations-12-17-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m12/m12v54-balancing-operations-12-17-2024.pdf},
-  bibtex_show = {true},
   abstract = {This manual focuses on the activities that occur in the real-time operation of
   the PJM Energy Market. The manual describes how PJM dispatches and controls Capacity
   Resources, and how PJM monitors transmission facilities. It also describes how PJM provides
-  Ancillary Services.},
+  Ancillary Services.}
 }
 
 @online{pjm2025m13,
@@ -906,11 +826,9 @@
   month = {February},
   day = {20},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m13/m13v95-emergency-operations-02-20-2025.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m13/m13v95-emergency-operations-02-20-2025.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Manual for Emergency Operations focuses on how PJM and the PJM Members are
   expected to respond to emergency conditions and is the designated PJM RC, BA and TOP
-  Operating Plan to mitigate operating Emergencies per EOP-011.},
+  Operating Plan to mitigate operating Emergencies per EOP-011.}
 }
 
 @online{pjm2024m14b,
@@ -921,13 +839,11 @@
   month = {September},
   day = {25},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14b/m14bv57-pjm-region-transmission-planning-process-09-25-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14b/m14bv57-pjm-region-transmission-planning-process-09-25-2024.pdf},
-  bibtex_show = {true},
   abstract = {The PJM Region Transmission Planning Process Manual is one of the PJM manuals in the
   PJM Regional Transmission Expansion group. This manual focuses on the process for planning
   baseline expansion facilities under the PJM Region Transmission Planning Process. Capitalized
   terms not defined as they are used have the meaning defined in the PJM's Open Access
-  Transmission Tariff (OATT) and in the Operating Agreement (OA.)},
+  Transmission Tariff (OATT) and in the Operating Agreement (OA.)}
 }
 
 @online{pjm2024m14d,
@@ -938,11 +854,9 @@
   month = {December},
   day = {18},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14d/m14dv66-generator-operational-requirements-12-18-2024.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14d/m14dv66-generator-operational-requirements-12-18-2024.pdf},
-  bibtex_show = {true},
   abstract = {This manual focuses on the markets and operations requirements for generating
   entities to connect to the PJM system and their responsibilities as signatories to the Operating
-  Agreement of PJM Interconnection, L.L.C.},
+  Agreement of PJM Interconnection, L.L.C.}
 }
 
 @online{pjm2025m14d,
@@ -953,11 +867,9 @@
   month = {March},
   day = {19},
   url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14d/m14dv67-generator-operational-requirements-03-19-2025.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14d/m14dv67-generator-operational-requirements-03-19-2025.pdf},
-  bibtex_show = {true},
   abstract = {This manual focuses on the markets and operations requirements for generating
   entities to connect to the PJM system and their responsibilities as signatories to the Operating
-  Agreement of PJM Interconnection, L.L.C.},
+  Agreement of PJM Interconnection, L.L.C.}
 }
 
 @misc{pjm2023dam,
@@ -967,9 +879,7 @@
   month = {July},
   year = {2023},
   day = {23},
-  url = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/mic/2023/20230717-special/item-02---day-ahead-market-clearing-process.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/mic/2023/20230717-special/item-02---day-ahead-market-clearing-process.pdf},
-  bibtex_show = {true},
+  url = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/mic/2023/20230717-special/item-02---day-ahead-market-clearing-process.pdf}
 }
 
 @online{nyiso2023tei,
@@ -979,9 +889,7 @@
   year = {2023},
   month = {January},
   day = {04},
-  url = {https://www.nyiso.com/documents/20142/2924447/tei_manual.pdf/94a26e65-fd68-98e1-535b-fc41a9536607},
-  pdf = {https://www.nyiso.com/documents/20142/2924447/tei_manual.pdf/94a26e65-fd68-98e1-535b-fc41a9536607},
-  bibtex_show = {true},
+  url = {https://www.nyiso.com/documents/20142/2924447/tei_manual.pdf/94a26e65-fd68-98e1-535b-fc41a9536607}
 }
 
 @article{hullermeier2021aleatoric,
@@ -996,7 +904,6 @@
   publisher = {Springer},
   doi = {10.1007/s10994-021-05946-3},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The notion of uncertainty is of major importance in machine learning and constitutes a key element
   of machine learning methodology. In line with the statistical tradition, uncertainty has long been perceived
   as almost synonymous with standard probability and probabilistic predictions. Yet, due to the steadily increasing
@@ -1005,7 +912,7 @@
   call for new methodological developments. In particular, this includes the importance of distinguishing between
   (at least) two different types of uncertainty, often referred to as aleatoric and epistemic. In this paper, we
   provide an introduction to the topic of uncertainty in machine learning as well as an overview of attempts so far
-  at handling uncertainty in general and formalizing this distinction in particular.},
+  at handling uncertainty in general and formalizing this distinction in particular.}
 }
 
 @online{ieee2014cascading,
@@ -1014,9 +921,7 @@
   year = {2014},
   month = {October},
   day = {23},
-  url = {https://www.naspi.org/sites/default/files/2016-09/ieee_vaiman_cascading_failures_20141023.pdf},
-  pdf = {https://www.naspi.org/sites/default/files/2016-09/ieee_vaiman_cascading_failures_20141023.pdf},
-  bibtex_show = {true},
+  url = {https://www.naspi.org/sites/default/files/2016-09/ieee_vaiman_cascading_failures_20141023.pdf}
 }
 
 @online{powerworld2020oscillations,
@@ -1024,9 +929,7 @@
   author = {PowerWorld},
   title = {Oscillations and Power System Stabilizers},
   year = {2020},
-  url = {https://www.powerworld.com/files/D11Stabilizers.pdf},
-  pdf = {https://www.powerworld.com/files/D11Stabilizers.pdf},
-  bibtex_show = {true},
+  url = {https://www.powerworld.com/files/D11Stabilizers.pdf}
 }
 
 @online{nerc2024datacenter,
@@ -1036,9 +939,7 @@
   year = {2024},
   month = {October},
   day = {21},
-  bibtex_show = {true},
-  url = {https://www.nerc.com/comm/RSTC/LMWG/Data%20Center%20Information%20Collection%20Questionnaire.pdf#search=Data%20Center%20Information%20Collection},
-  pdf = {https://www.nerc.com/comm/RSTC/LMWG/Data%20Center%20Information%20Collection%20Questionnaire.pdf#search=Data%20Center%20Information%20Collection},
+  url = {https://www.nerc.com/comm/RSTC/LMWG/Data%20Center%20Information%20Collection%20Questionnaire.pdf#search=Data%20Center%20Information%20Collection}
 }
 
 @online{giraldez2024large,
@@ -1048,10 +949,7 @@
   year = {2024},
   month = {October},
   day = {22},
-  bibtex_show = {true},
-  url = {https://www.esig.energy/download/session-4a-large-loads-interconnection-planning-and-reliability-considerations-julieta-giraldez-and-ahmed-rashwan/?wpdmdl=12224&refresh=671fa495d3a361730126997},
-  pdf = {https://www.esig.energy/download/session-4a-large-loads-interconnection-planning-and-reliability-considerations-julieta-giraldez-and-ahmed-rashwan/?wpdmdl=12224&refresh=671fa495d3a361730126997},
-  html = {https://www.esig.energy/download/session-4a-large-loads-interconnection-planning-and-reliability-considerations-julieta-giraldez-and-ahmed-rashwan/},
+  url = {https://www.esig.energy/download/session-4a-large-loads-interconnection-planning-and-reliability-considerations-julieta-giraldez-and-ahmed-rashwan/}
 }
 
 @online{shah2024interconnection,
@@ -1061,10 +959,7 @@
   year = {2024},
   month = {October},
   day = {22},
-  url = {https://www.esig.energy/download/session-4a-interconnection-and-integration-of-large-loads-pooja-shah-and-harish-sharma/?wpdmdl=12221&refresh=671fa4964876b1730126998},
-  pdf = {https://www.esig.energy/download/session-4a-interconnection-and-integration-of-large-loads-pooja-shah-and-harish-sharma/?wpdmdl=12221&refresh=671fa4964876b1730126998},
-  html = {https://www.esig.energy/download/session-4a-interconnection-and-integration-of-large-loads-pooja-shah-and-harish-sharma/},
-  bibtex_show = {true},
+  url = {https://www.esig.energy/download/session-4a-interconnection-and-integration-of-large-loads-pooja-shah-and-harish-sharma/}
 }
 
 @online{pjm2024colocated,
@@ -1074,9 +969,7 @@
   year = {2024},
   month = {April},
   day = {17},
-  bibtex_show = {true},
-  url = {https://www.pjm.com/-/media/DotCom/markets-ops/rpm/rpm-auction-info/pjm-guidance-on-co-located-load.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/markets-ops/rpm/rpm-auction-info/pjm-guidance-on-co-located-load.pdf},
+  url = {https://www.pjm.com/-/media/DotCom/markets-ops/rpm/rpm-auction-info/pjm-guidance-on-co-located-load.pdf}
 }
 
 @online{nerc2020ffr,
@@ -1086,9 +979,7 @@
   year = {2020},
   month = {April},
   day = {16},
-  bibtex_show = {true},
-  url = {https://www.nerc.com/comm/PC/IRPTF_Webinars_DL/2020-04_Webinar-FFR_White_Paper.pdf},
-  pdf = {https://www.nerc.com/comm/PC/IRPTF_Webinars_DL/2020-04_Webinar-FFR_White_Paper.pdf},
+  url = {https://www.nerc.com/comm/PC/IRPTF_Webinars_DL/2020-04_Webinar-FFR_White_Paper.pdf}
 }
 
 @article{ieee2024std1547,
@@ -1098,8 +989,7 @@
   year = {2024},
   pages = {1-291},
   doi = {10.1109/IEEESTD.2024.10534228},
-  dimensions = {false},
-  bibtex_show = {true},
+  dimensions = {false}
 }
 
 @article{ieee2025std2988,
@@ -1108,12 +998,11 @@
   title = {IEEE Recommended Practice for Use and Functions of Virtual Synchronous Machines},
   year = {2025},
   pages = {1-52},
-  bibtex_show = {true},
   doi = {10.1109/IEEESTD.2025.10850696},
   abstract = {The fundamental principles, essential functions, and optional functions of a virtual synchronous machine (VSM) to make
   power electronic converters standardized for different applications and suitable for single-unit operation, multi-unit operation,
   islanded/off-grid operation, and grid-tied operation, facilitating the large-scale utilization of DER and the integration of power
-  electronic converters into the grid, and advancing energy freedom and energy access are defined in this standard.},
+  electronic converters into the grid, and advancing energy freedom and energy access are defined in this standard.}
 }
 
 @article{hatziargyriou2020stabilityreport,
@@ -1127,7 +1016,6 @@
   month = {May},
   day = {30},
   dimensions = {false},
-  bibtex_show = {true},
   abstract = {A task force set up jointly by IEEE Power System Dynamic Performance Committee (PSDPC) and CIGRE had addressed the
   issue of stability definition and classification in power systems from a fundamental viewpoint and had closely examined the practical
   ramifications. The relevant report published in 2004, primarily dealt with fairly slow, electromechanical phenomena, typically
@@ -1136,7 +1024,7 @@
   and has progressively become more dependent on (complex) fast-response power electronic devices, thus arising new stability concerns.
   In recognition of this change, a Task Force was established by IEEE PSDPC in 2016 to re-examine and extend, where appropriate, the classic
   definitions and classifications of the basic stability terms. This report summarizes the results of this work and presents extended
-  definitions, characterization and classification of power system stability.},
+  definitions, characterization and classification of power system stability.}
 }
 
 @article{ieee1980subsynchronous,
@@ -1150,11 +1038,10 @@
   pages = {506-511},
   doi = {10.1109/TPAS.1980.319686},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {This paper presents proposed terms, definitions and symbols in pursuit of Electric Utility Industry uniformity and common understanding
   in the analysis of subsynchronous resonance. For the purpose of this paper the discussion is limited to series compensated transmission
   systems. These definitions are recommended, where applicable, in other unique areas encompassing subsynchronous oscillations. The work presented
-  is a product of the Subsynchronous Resonance Working Group as part of the activity of the IEEE System Dynamic Performance Subcommittee.},
+  is a product of the Subsynchronous Resonance Working Group as part of the activity of the IEEE System Dynamic Performance Subcommittee.}
 }
 
 @online{powerworld2025manual,
@@ -1162,9 +1049,7 @@
   author = {PowerWorld},
   title = {PowerWorld Manual},
   year = {2025},
-  url = {http://www.powerworld.com/WebHelp},
-  html = {http://www.powerworld.com/WebHelp},
-  bibtex_show = {true},
+  url = {http://www.powerworld.com/WebHelp}
 }
 
 @online{pjm2022cooptimization,
@@ -1175,10 +1060,8 @@
   month = {June},
   day = {1},
   url = {https://www.pjm.com/-/media/DotCom/committees-groups/task-forces/epfstf/2022/20220630/informational-posting---energy-and-ancillary-service-co-optimization-formulation.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/committees-groups/task-forces/epfstf/2022/20220630/informational-posting---energy-and-ancillary-service-co-optimization-formulation.pdf},
-  bibtex_show = {true},
   abstract = {This document provides a high-level mathematical formulation and explanation of the objective function used in the 
-  clearing of the Energy and Ancillary Service Markets. The intent of this document is to provide a better understanding of the mechanics.},
+  clearing of the Energy and Ancillary Service Markets. The intent of this document is to provide a better understanding of the mechanics.}
 }
 
 @online{nyiso2024ancillary,
@@ -1189,9 +1072,7 @@
   month = {August},
   day = {2},
   url = {https://www.nyiso.com/documents/20142/43891523/M-02-Ancillary-Services-Manual.pdf/653fb105-8b85-48b8-edcc-bc21f62a2ef9},
-  pdf = {https://www.nyiso.com/documents/20142/43891523/M-02-Ancillary-Services-Manual.pdf/653fb105-8b85-48b8-edcc-bc21f62a2ef9},
-  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. NYISO may have issued an updated version — check https://www.nyiso.com/manuals-tech-bulletins-user-guides for the current M-02 manual.},
-  bibtex_show = {true},
+  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. NYISO may have issued an updated version — check https://www.nyiso.com/manuals-tech-bulletins-user-guides for the current M-02 manual.}
 }
 
 @online{nyiso2025ancillary,
@@ -1201,9 +1082,7 @@
   year = {2025},
   month = {May},
   day = {1},
-  url = {https://www.nyiso.com/documents/20142/2923301/ancserv.pdf/df83ac75-c616-8c89-c664-99dfea06fe2f},
-  pdf = {https://www.nyiso.com/documents/20142/2923301/ancserv.pdf/df83ac75-c616-8c89-c664-99dfea06fe2f},
-  bibtex_show = {true},
+  url = {https://www.nyiso.com/documents/20142/2923301/ancserv.pdf/df83ac75-c616-8c89-c664-99dfea06fe2f}
 }
 
 @online{nyiso2024dayahead,
@@ -1213,9 +1092,7 @@
   year = {2024},
   month = {October},
   Day = {29},
-  url = {https://www.nyiso.com/documents/20142/2923301/dayahd-schd-mnl.pdf/0024bc71-4dd9-fa80-a816-f9f3e26ea53a},
-  pdf = {https://www.nyiso.com/documents/20142/2923301/dayahd-schd-mnl.pdf/0024bc71-4dd9-fa80-a816-f9f3e26ea53a},
-  bibtex_show = {true},
+  url = {https://www.nyiso.com/documents/20142/2923301/dayahd-schd-mnl.pdf/0024bc71-4dd9-fa80-a816-f9f3e26ea53a}
 }
 
 @online{pjm2021reliability,
@@ -1225,9 +1102,7 @@
   year = {2021},
   month = {March},
   day = {11},
-  url = {https://www.pjm.com/-/media/DotCom/library/reports-notices/special-reports/2021/20210311-reliability-in-pjm-today-and-tomorrow.ashx},
-  pdf = {https://www.pjm.com/-/media/DotCom/library/reports-notices/special-reports/2021/20210311-reliability-in-pjm-today-and-tomorrow.ashx},
-  bibtex_show = {true},
+  url = {https://www.pjm.com/-/media/DotCom/library/reports-notices/special-reports/2021/20210311-reliability-in-pjm-today-and-tomorrow.ashx}
 }
 
 @online{pjm2021capacity,
@@ -1237,8 +1112,7 @@
   year = {2021},
   month = {November},
   day = {4},
-  url = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/oc/2021/20211104/20211104-item-13-reliability-products-and-services-assessment.ashx},
-  pdf = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/oc/2021/20211104/20211104-item-13-reliability-products-and-services-assessment.ashx},
+  url = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/oc/2021/20211104/20211104-item-13-reliability-products-and-services-assessment.ashx}
 }
 
 @online{pjm2022reliability,
@@ -1248,9 +1122,7 @@
   year = {2022},
   month = {February},
   day = {07},
-  url = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/oc/2022/20220210/20220210-item-16-reliability-products-and-service-assessment.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/oc/2022/20220210/20220210-item-16-reliability-products-and-service-assessment.pdf},
-  bibtex_show = {true},
+  url = {https://www.pjm.com/-/media/DotCom/committees-groups/committees/oc/2022/20220210/20220210-item-16-reliability-products-and-service-assessment.pdf}
 }
 
 @article{bollen2003voltage,
@@ -1264,12 +1136,11 @@
   pages = {1376-1381},
   doi = {10.1109/TPWRD.2003.817725},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {This paper studies the recovery of the voltage after a voltage dip due to a fault in a three-phase system. The instant of voltage
   recovery corresponds to the instant of fault clearing. For single-phase and phase-to-phase faults, a single point-on-wave of voltage recovery can
   be defined. For two-phase-to-ground and three-phase faults, the recovery takes place in two or three steps. The voltage recovery is described in
   a systematic way by using a classification of three-phase unbalanced voltage dips. The voltage recovery needs to be modeled correctly for studies
-  of equipment immunity against voltage dips.},
+  of equipment immunity against voltage dips.}
 }
 
 @online{specialists2023voltage,
@@ -1279,9 +1150,7 @@
   year = {2023},
   month = {June},
   day = {22},
-  url = {https://transientspecialists.com/blogs/blog/voltage-dips-interruptions-iec-61000-4-11-iec-61000-4-34},
-  html = {https://transientspecialists.com/blogs/blog/voltage-dips-interruptions-iec-61000-4-11-iec-61000-4-34},
-  bibtex_show = {true},
+  url = {https://transientspecialists.com/blogs/blog/voltage-dips-interruptions-iec-61000-4-11-iec-61000-4-34}
 }
 
 @online{nerc2023faq,
@@ -1291,9 +1160,7 @@
   year = {2023},
   month = {March},
   url = {http://web.archive.org/web/20250829001613/https://www.nerc.com/news/Documents/March%202023%20NERC%20Frequently%20Asked%20Questions%20FAQ.pdf},
-  pdf = {http://web.archive.org/web/20250829001613/https://www.nerc.com/news/Documents/March%202023%20NERC%20Frequently%20Asked%20Questions%20FAQ.pdf},
-  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-08-29).},
-  bibtex_show = {true},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-08-29).}
 }
 
 @article{sun2022datacenter,
@@ -1308,7 +1175,6 @@
   pages = {8420-8432},
   doi = {10.1109/TPEL.2022.3146354},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Data centers have become a widespread power electronics (PE) load, which has significant impact on the
   power grid. In order to investigate the data center load characteristics, this article proposes a complete dynamic model
   for a typical data center ac power distribution system. A generalized model with mode transition is proposed to
@@ -1319,7 +1185,7 @@
   in a regional network. Dynamic performances during voltage sag events and server load variations are emulated and
   discussed. The article details the design, development, and verification of the data center model and power emulator.
   The proposed model and emulator provide an effective, easy-to-use tool to better design data centers and study the
-  interaction with the power system.},
+  interaction with the power system.}
 }
 
 @article{ieee2024std1547,
@@ -1332,7 +1198,6 @@
   year = {2024},
   month = {December},
   dimensions = {false},
-  bibtex_show = {true},
   abstract = {The concept of synchro-waveforms has recently emerged as a promising frontier in power system monitoring and
   data-driven applications. By providing access to raw waveform samples, synchro-waveforms can capture not only the typical
   major disturbances but also the seemingly minor, yet sometimes highly informative, disturbances in voltage and current
@@ -1351,7 +1216,7 @@
   insights and suggestions for future directions in this field. This report serves as a resource for industry, academia, and
   all stakeholders interested in leveraging synchro-waveform data for enhanced situational awareness and other power system
   applications. Its ultimate goal is to raise awareness within the power systems community and related disciplines about the
-  growing field of synchro-waveforms and the diverse range of emerging topics in this domain.},
+  growing field of synchro-waveforms and the diverse range of emerging topics in this domain.}
 }
 
 @online{isone2024op19,
@@ -1361,9 +1226,7 @@
   year = {2024},
   month = {June},
   day = {12},
-  url = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/isone/op19/op19_rto_final.pdf},
-  pdf = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/isone/op19/op19_rto_final.pdf},
-  bibtex_show = {true},
+  url = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/isone/op19/op19_rto_final.pdf}
 }
 
 @online{isone2024crop34007,
@@ -1373,9 +1236,7 @@
   year = {2024},
   month = {January},
   day = {19},
-  url = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/sysop/cr_ops/crop_34007.pdf},
-  pdf = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/sysop/cr_ops/crop_34007.pdf},
-  bibtex_show = {true},
+  url = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/sysop/cr_ops/crop_34007.pdf}
 }
 
 @online{isone2024op19j,
@@ -1385,9 +1246,7 @@
   year = {2024},
   month = {April},
   day = {24},
-  url = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/isone/op19/op19j_rto_final.pdf},
-  pdf = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/isone/op19/op19j_rto_final.pdf},
-  bibtex_show = {true},
+  url = {https://www.iso-ne.com/static-assets/documents/rules_proceds/operating/isone/op19/op19j_rto_final.pdf}
 }
 
 @online{entsoe2019cracmodel,
@@ -1398,11 +1257,9 @@
   month = {December},
   day = {12},
   url = {https://eepublicdownloads.entsoe.eu/clean-documents/EDI/Library/cim_based/Contingency%20list,%20remedial%20actions%20and%20additional%20constraints_document%20UML%20model%20and%20schema_v2.4.pdf},
-  pdf = {https://eepublicdownloads.entsoe.eu/clean-documents/EDI/Library/cim_based/Contingency%20list,%20remedial%20actions%20and%20additional%20constraints_document%20UML%20model%20and%20schema_v2.4.pdf},
-  bibtex_show = {true},
   abstract = {The purpose of this document is to provide the contextual and assembly UML models and the schema of the CRAC_MarketDocument.
   The schema of the CRAC_MarketDocument could be used in various business processes.
-  It is not the purpose of this document to describe all the use cases, sequence diagrams, business processes, etc. for which this schema is to be used.},
+  It is not the purpose of this document to describe all the use cases, sequence diagrams, business processes, etc. for which this schema is to be used.}
 }
 
 @online{entsoe2019crac,
@@ -1413,12 +1270,10 @@
   month = {September},
   day = {10},
   url = {https://eepublicdownloads.entsoe.eu/clean-documents/EDI/Library/crac/CRAC_implementation_guide_v2r3.pdf},
-  pdf = {https://eepublicdownloads.entsoe.eu/clean-documents/EDI/Library/crac/CRAC_implementation_guide_v2r3.pdf},
-  bibtex_show = {true},
   abstract = {The objective of this implementation guide is to make it possible for software vendors to develop an IT application for TSO and RSC
   to exchange information relative to contingency list, remedial actions and additional constraints used for coordinated capacity calculation process.
   The implementation guide is one of the building blocks for using UML (Unified Modelling Language) based techniques in defining processes and
-  messages for interchange between actors in the electrical industry in Europe.},
+  messages for interchange between actors in the electrical industry in Europe.}
 }
 
 @inproceedings{baranowski2012operational,
@@ -1430,12 +1285,11 @@
   pages = {1-4},
   doi = {10.1109/PESGM.2012.6345118},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Evaluating the impact of unplanned outages is a key aspect of real-time operations at PJM. Contingency
   evaluation impacts the decisions of the various application users. Transmission Dispatchers, Generation Dispatchers
   and Operations Planners evaluate contingencies that affect their decisions regarding transmission system reliability
   and markets. This paper presents various aspects of the contingency usage at PJM including the applications that
-  utilize contingency lists, modeling of contingencies and monitoring of contingency results.},
+  utilize contingency lists, modeling of contingencies and monitoring of contingency results.}
 }
 
 @online{ferc2021texas,
@@ -1444,9 +1298,7 @@
   title = {The February 2021 Cold Weather Outages in Texas and the South Central United States},
   year = {2021},
   month = {November},
-  url = {https://www.ferc.gov/media/february-2021-cold-weather-outages-texas-and-south-central-united-states-ferc-nerc-and},
-  html = {https://www.ferc.gov/media/february-2021-cold-weather-outages-texas-and-south-central-united-states-ferc-nerc-and},
-  bibtex_show = {true},
+  url = {https://www.ferc.gov/media/february-2021-cold-weather-outages-texas-and-south-central-united-states-ferc-nerc-and}
 }
 
 @online{svitek2022texas,
@@ -1456,9 +1308,7 @@
   year = {2022},
   month = {January},
   day = {2},
-  url = {https://www.texastribune.org/2022/01/02/texas-winter-storm-final-death-toll-246/},
-  html = {https://www.texastribune.org/2022/01/02/texas-winter-storm-final-death-toll-246/},
-  bibtex_show = {true},
+  url = {https://www.texastribune.org/2022/01/02/texas-winter-storm-final-death-toll-246/}
 }
 
 @online{king2021texas,
@@ -1468,8 +1318,6 @@
   year = {2021},
   month = {July},
   url = {https://energy.utexas.edu/sites/default/files/UTAustin%20%282021%29%20EventsFebruary2021TexasBlackout%2020210714.pdf},
-  pdf = {https://energy.utexas.edu/sites/default/files/UTAustin%20%282021%29%20EventsFebruary2021TexasBlackout%2020210714.pdf},
-  bibtex_show = {true},
   abstract = {This report recounts the factors contributing to disruptions in electricity and natural 
   gas service in Texas during Winter Storm Uri, with a particular focus on blackouts on 
   the Electric Reliability Council of Texas (ERCOT) grid during the period from February 
@@ -1482,7 +1330,7 @@
   historical context. 
   This report is not intended to comprehensively address all issues stemming from 
   such a complex event, but may inform subsequent assessments. This report does 
-  not recommend policies or solutions.},
+  not recommend policies or solutions.}
 }
 
 @article{fuller2020digital,
@@ -1496,7 +1344,6 @@
   pages = {108952-108971},
   doi = {10.1109/ACCESS.2020.2998358},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Digital Twin technology is an emerging concept that has become the centre of attention
   for industry and, in more recent years, academia. The advancements in industry 4.0 concepts have
   facilitated its growth, particularly in the manufacturing industry. The Digital Twin is defined
@@ -1506,7 +1353,7 @@
   publications relating to Digital Twins is performed, producing a categorical review of recent papers.
   The review has categorised them by research areas: manufacturing, healthcare and smart cities,
   discussing a range of papers that reflect these areas and the current state of research. The paper
-  provides an assessment of the enabling technologies, challenges and open research for Digital Twins.},
+  provides an assessment of the enabling technologies, challenges and open research for Digital Twins.}
 }
 
 @online{epa2024gridregions,
@@ -1516,9 +1363,7 @@
   year = {2024},
   month = {December},
   day = {26},
-  url = {https://www.epa.gov/green-power-markets/us-grid-regions},
-  html = {https://www.epa.gov/green-power-markets/us-grid-regions},
-  bibtex_show = {true},
+  url = {https://www.epa.gov/green-power-markets/us-grid-regions}
 }
 
 @online{tc2021iec61970,
@@ -1529,10 +1374,8 @@
   month = {June},
   day = {04},
   url = {https://webstore.iec.ch/en/publication/63866},
-  html = {https://webstore.iec.ch/en/publication/63866},
-  bibtex_show = {true},
   abstract = {Energy management system application program interface (EMS-API) - Part 600-1: Common Grid Model
-  Exchange Standard (CGMES) - Structure and rules},
+  Exchange Standard (CGMES) - Structure and rules}
 }
 
 @online{ferc2021rule,
@@ -1542,8 +1385,7 @@
   year = {2021},
   month = {December},
   day = {16},
-	url = {https://www.ferc.gov/news-events/news/ferc-rule-improve-transmission-line-ratings-will-help-lower-transmission-costs},
-	html = {https://www.ferc.gov/news-events/news/ferc-rule-improve-transmission-line-ratings-will-help-lower-transmission-costs},
+	url = {https://www.ferc.gov/news-events/news/ferc-rule-improve-transmission-line-ratings-will-help-lower-transmission-costs}
 }
 
 @online{pjm2022dlr,
@@ -1554,11 +1396,10 @@
   month = {October},
   day = {24},
 	url = {https://www.ferc.gov/news-events/news/ferc-rule-improve-transmission-line-ratings-will-help-lower-transmission-costs},
-	html = {https://www.powermag.com/understanding-the-april-2025-iberian-peninsula-blackout-early-analysis-and-lessons-learned/},
   abstract = {Initiated in 2020 by transmission owner PPL Electric Utilities and facilitated by PJM, PPL Electric Utilities has
   said it expects the activation of dynamic line rating (DLR) technology to expand capacity and promote market efficiency on
   three historically congested lines. PPL Electric Utilities estimates that this DLR project can save customers $23 million
-  annually in congestion costs.},
+  annually in congestion costs.}
 }
 
 @online{larson2025iberian,
@@ -1568,8 +1409,7 @@
   year = {2025},
   month = {May},
   day = {8},
-	url = {https://www.powermag.com/understanding-the-april-2025-iberian-peninsula-blackout-early-analysis-and-lessons-learned/},
-	html = {https://www.powermag.com/understanding-the-april-2025-iberian-peninsula-blackout-early-analysis-and-lessons-learned/},
+	url = {https://www.powermag.com/understanding-the-april-2025-iberian-peninsula-blackout-early-analysis-and-lessons-learned/}
 }
 
 @online{leader2025iberian,
@@ -1579,8 +1419,7 @@
   year = {2025},
   month = {May},
   day = {9},
-	url = {https://sepapower.org/knowledge/april-2025-iberian-blackout/},
-	html = {https://sepapower.org/knowledge/april-2025-iberian-blackout/},
+	url = {https://sepapower.org/knowledge/april-2025-iberian-blackout/}
 }
 
 @online{miso2023ferc881,
@@ -1590,8 +1429,7 @@
   year = {2023},
   month = {Aug},
   day = {22},
-	pdf = {https://cdn.misoenergy.org/20230822%20RSC%20Item%2005%20FERC%20Order%20881%20Update%20(RSC%202018%2054A)%20(RSC%202021%2054B)629904.pdf},
-  url = {https://cdn.misoenergy.org/20230822%20RSC%20Item%2005%20FERC%20Order%20881%20Update%20(RSC%202018%2054A)%20(RSC%202021%2054B)629904.pdf},
+  url = {https://cdn.misoenergy.org/20230822%20RSC%20Item%2005%20FERC%20Order%20881%20Update%20(RSC%202018%2054A)%20(RSC%202021%2054B)629904.pdf}
 }
 
 @online{neso2025electricity,
@@ -1599,9 +1437,7 @@
   author = {NESO},
   title = {Electricity Markets Explained},
   year = {2025},
-  url = {https://www.neso.energy/what-we-do/energy-markets/electricity-markets-explained},
-  html = {https://www.neso.energy/what-we-do/energy-markets/electricity-markets-explained},
-  bibtex_show = {true},
+  url = {https://www.neso.energy/what-we-do/energy-markets/electricity-markets-explained}
 }
 
 @online{epri2022operatingenvelopes,
@@ -1611,8 +1447,6 @@
   year = {2022},
   month = {Jul},
   url = {https://www.epri.com/research/products/000000003002025065},
-  html = {https://www.epri.com/research/products/000000003002025065},
-  bibtex_show = {true},
   abstract = {The interconnection of distributed energy resources (DER) that can inject and absorb power to and from the distribution
   system, such as distributed generation and electric energy storage systems, is expected to increase in support of societal goals and as
   technologies mature. The cost to interconnect new DER will tend to increase as hosting capacity is consumed and grid infrastructure
@@ -1622,7 +1456,7 @@
   and/or year. As the remaining hosting capacity shrinks with rising DER penetrations there is interest in utilizing the additional hosting
   capacity that is available outside of those worst-case conditions. Capabilities to utilize more “flexible” DER interconnections (for both
   generation and demand resources) that can be managed in concert and controlled dynamically will likely become a viable means to maximize
-  the use of DER within the operating limits of the grid.},
+  the use of DER within the operating limits of the grid.}
 }
 
 @article{alam2024dynamicenvelopes,
@@ -1635,7 +1469,6 @@
   number = {1},
   pages = {173-186},
   doi = {10.1109/TSTE.2023.3275082},
-  bibtex_show = {true},
   dimensions = {true},
   abstract = {A Dynamic Operating Envelope (DOE) specifies the available capacity to import/export power for Distributed Energy Resources
   (DERs) or connection points of a distribution network in a time interval without violating its physical and operational constraints.
@@ -1648,7 +1481,7 @@
   to demonstrate the effectiveness of proposed approach. Test results show that technical perspective can offer maximum allocated export/import
   power, whereas, minimum disparity of allocated power among different connection-points is attained for equitable perspective. Further,
   insightful performance studies of DOE and existing fixed export policies are conducted considering the condition of present as well as
-  future power systems expecting substantial proliferations of renewables.},
+  future power systems expecting substantial proliferations of renewables.}
 }
 
 @article{attarha2022networksecure,
@@ -1662,7 +1495,6 @@
   pages = {2050-2062},
   doi = {10.1109/TSG.2021.3138099},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {As our power system modernises to embrace consumer-owned distributed energy resources (DER), network operators must ensure
   a safe and reliable operation while enabling consumers to trade their flexibility in the wholesale market. To enable this, we obtain
   network-secure operating envelopes that facilitate participation of consumers in energy and reserve markets. Given the distributed
@@ -1672,7 +1504,7 @@
   nor penalises DER-owners (due to market bid violation), we introduce a piecewise affinely adjustable robust bidding approach that
   can compensate for uncertainty variations in real-time. We also open up network capacity and minimise its losses, by proposing an
   additional piecewise affine Q-P controller that exchanges inverter reactive power with the grid. Our results on a 69-bus distribution
-  network highlight the effectiveness of our proposal compared to alternative approaches.},
+  network highlight the effectiveness of our proposal compared to alternative approaches.}
 }
 
 @techreport{nerc2025largeloads,
@@ -1682,8 +1514,6 @@
   year = {2025},
   month = {Jul},
   url = {https://www.nerc.com/comm/RSTC_Reliability_Guidelines/Whitepaper%20Characteristics%20and%20Risks%20of%20Emerging%20Large%20Loads.pdf},
-  pdf = {https://www.nerc.com/comm/RSTC_Reliability_Guidelines/Whitepaper%20Characteristics%20and%20Risks%20of%20Emerging%20Large%20Loads.pdf},
-  bibtex_show = {true},
   abstract = {NERC's Reliability and Security Technical Committee (RSTC) established the Large Load Task Force (LLTF) to analyze the
   reliability impacts related to emerging large loads (e.g., data centers (including cryptocurrency mining and AI), industrial facilities,
   and hydrogen production facilities). This white paper characterizes large loads and defines the reliability risks that they may pose
@@ -1691,7 +1521,7 @@
   loads examined in this paper range in size from several megawatts to several gigawatts, posing novel challenges to the reliability
   and security of the BPS. Several Reliability Coordinators (RC) and utilities have existing large-load constructs based primarily on
   facility peak demand. However, additional characteristics should be considered in any definition of large loads, as this white paper
-  shows that peak demand is only one of many characteristics that can impact BPS reliability.},
+  shows that peak demand is only one of many characteristics that can impact BPS reliability.}
 }
 
 @article{spyrou2025flexibilityoptions,
@@ -1705,7 +1535,6 @@
   pages = {260-273},
   doi = {10.1109/TEMPR.2025.3529689},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The presence of variable renewable energy resources with uncertain outputs in day-ahead electricity markets results in
   additional balancing needs in real-time. Addressing those needs cost-effectively and reliably within a competitive market with
   unbundled products is challenging as both the demand for and the availability of flexibility depends on day-ahead energy schedules.
@@ -1717,7 +1546,7 @@
   energy supply. As we illustrate with numerical examples and mathematical analysis, the product addresses the hedging needs of
   participants with imbalances cost-effectively, provides a less intermittent revenue stream for participants with flexible outputs,
   promotes value-driven pricing of flexibility, and ensures that the system operator is revenue-neutral. This article provides a
-  comprehensive design that can be further tested and applied in large-scale systems.},
+  comprehensive design that can be further tested and applied in large-scale systems.}
 }
 
 @online{nyiso2025interconnectionprocess,
@@ -1725,9 +1554,7 @@
  title = {Interconnection Process},
  author = {NYISO},
  url = {https://www.nyiso.com/interconnections},
- html = {https://www.nyiso.com/interconnections},
- bibtex_show = {true},
- year = {2025},
+ year = {2025}
 }
 
 @online{sun2021frequency,
@@ -1735,9 +1562,7 @@
   author = {Kai Sun},
   title = {ECE 522 - Power Systems Analysis II: Frequency Regulation and Control},
   year = {2021},
-  url = {https://web.eecs.utk.edu/~kaisun/ECE522/ECE522_4-Frequency.pdf},
-  pdf = {https://web.eecs.utk.edu/~kaisun/ECE522/ECE522_4-Frequency.pdf},
-  bibtex_show = {true},
+  url = {https://web.eecs.utk.edu/~kaisun/ECE522/ECE522_4-Frequency.pdf}
 }
 
 @book{slotine1990appliednonlinear,
@@ -1748,8 +1573,7 @@
   month = {October},
   year =  {1990},
   address = {Upper Saddle River, NJ},
-  isbn = {9861541381},
-  bibtex_show = {true},
+  isbn = {9861541381}
 }
 
 @techreport{nyiso2025emtguideline,
@@ -1758,9 +1582,7 @@
   author = {NYISO},
   year = {2025},
   month = {June},
-  url = {https://www.nyiso.com/documents/20142/3625950/UG-28-EMT-v2.0-Final.pdf},
-  pdf = {https://www.nyiso.com/documents/20142/3625950/UG-28-EMT-v2.0-Final.pdf},
-  bibtex_show = {true},
+  url = {https://www.nyiso.com/documents/20142/3625950/UG-28-EMT-v2.0-Final.pdf}
 }
 
 @article{eu2017guideline,
@@ -1773,9 +1595,7 @@
   number = {1485/2017},
   month = {August},
   day = {25},
-  url = {http://data.europa.eu/eli/reg/2017/1485/oj},
-  html = {http://data.europa.eu/eli/reg/2017/1485/oj},
-  bibtex_show = {true},
+  url = {http://data.europa.eu/eli/reg/2017/1485/oj}
 }
 
 @online{miso2024drr,
@@ -1786,9 +1606,7 @@
   month = {May},
   day = {30},
   year = {2024},
-  url = {https://cdn.misoenergy.org/20240530%20RSC%20Item%2006a%20Dynamic%20Regulation%20Reserve%20Requirement%20Presentation%20RSC-2024-1632972.pdf},
-  pdf = {https://cdn.misoenergy.org/20240530%20RSC%20Item%2006a%20Dynamic%20Regulation%20Reserve%20Requirement%20Presentation%20RSC-2024-1632972.pdf},
-  bibtex_show = {true},
+  url = {https://cdn.misoenergy.org/20240530%20RSC%20Item%2006a%20Dynamic%20Regulation%20Reserve%20Requirement%20Presentation%20RSC-2024-1632972.pdf}
 }
 
 @online{entsoe2015dsm,
@@ -1796,9 +1614,7 @@
   author = {ENTSO-E},
   title = {Instruction manual Dynamic Study Model Range of Applications and Modelling Basis V6.1},
   year = {2015},
-  url = {https://eepublicdownloads.entsoe.eu/clean-documents/Publications/SOC/Continental_Europe/InitialDynamicModel_Handbook_gen.pdf},
-  pdf = {https://eepublicdownloads.entsoe.eu/clean-documents/Publications/SOC/Continental_Europe/InitialDynamicModel_Handbook_gen.pdf},
-  bibtex_show = {true},
+  url = {https://eepublicdownloads.entsoe.eu/clean-documents/Publications/SOC/Continental_Europe/InitialDynamicModel_Handbook_gen.pdf}
 }
 
 @ARTICLE{tsaousoglou2023new,
@@ -1812,7 +1628,6 @@
   pages = {131-144},
   doi = {10.1109/TEMPR.2023.3259028},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Modern power systems face important demand uncertainties due to increasing penetration of behind-the-meter renewable generation.
   System operators need to account for such uncertainties when solving the unit commitment and economic dispatch problem. The research
   literature has proposed advanced methods for decision making under uncertainty but, in practice, actual system operators put more trust in the
@@ -1822,7 +1637,7 @@
   reserve activation in all of those timeslots due to the battery's energy being depleted. After discussing two plausible but inadequate approaches,
   a new, generalized notion of reserves is proposed, which addresses these issues while not abandoning the practical, reserve-based approach for
   the operator's problem, thus making the best of both worlds. The proposed scheme enables storage units to provide reserves, without putting the
-  system at risk of energy scarcity, which is shown to result in substantial cost savings.},
+  system at risk of energy scarcity, which is shown to result in substantial cost savings.}
 }
 
 @article{kaya2026fifty,
@@ -1840,7 +1655,6 @@
   month = {February},
   pages = {1-23},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {This review paper examines the evolution of power systems optimization over the past fifty years by considering two distinct
   periods: from 1970 to 1990 and from 1990 to the present. The initial period is typically defined by a centralized power system framework
   that prevailed around the world. The latter observes a transition to a decentralized structure in a market environment, marked by an
@@ -1849,7 +1663,7 @@
   operation planning, operations, control, and forecasting — to define the main research streams. We provide a thorough exploration of the
   operations research methods applied to specific problem types within each period. Thus, this review not only underscores the pivotal role
   of operations research in addressing the challenges posed by changing landscapes and advanced technologies but also unveils the transformative
-  journey of power systems optimization along with future research directions.},
+  journey of power systems optimization along with future research directions.}
 }
 
 @online{nerc2017integrating,
@@ -1858,9 +1672,7 @@
   title = {Integrating Inverter-Based Resources into Low Short Circuit Strength Systems},
   year = {2017},
   month = {December},
-  url = {https://www.nerc.com/globalassets/who-we-are/standing-committees/rstc/irpwg/item_4a._integrating-_inverter-based_resources_into_low_short_circuit_strength_systems_-_2017-11-08-final.pdf},
-  pdf = {https://www.nerc.com/globalassets/who-we-are/standing-committees/rstc/irpwg/item_4a._integrating-_inverter-based_resources_into_low_short_circuit_strength_systems_-_2017-11-08-final.pdf},
-  bibtex_show = {true},
+  url = {https://www.nerc.com/globalassets/who-we-are/standing-committees/rstc/irpwg/item_4a._integrating-_inverter-based_resources_into_low_short_circuit_strength_systems_-_2017-11-08-final.pdf}
 }
 
 @inproceedings{zhang2014evaluating,
@@ -1874,14 +1686,13 @@
   pages={1-5},
   doi={10.1109/PESGM.2014.6939043},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The performance of various components in a power system, from voltage stability perspective, is highly dependent on the system
   strength. Voltage stability issues can be caused by integrating a large amount of wind generation into a weak grid. Short circuit ratio
   (SCR) is often used as an index of the system strength. SCR provides wind plants a reference to properly tune controller settings and coordinate
   with neighboring plants. The commonly used SCR calculation method does not consider interactions between wind plants, therefore gives an
   overly-optimistic estimation of the system strength. This paper proposes the concept of weighted short circuit ratio (WSCR), which takes interactions
   between wind plants into account. The WSCR can better reflect the actual system strength when integrating a large amount of wind plants in a weak
-  system. The paper also proposes a procedure to determine the optimal synchronous condenser ratings and locations to improve the overall system strength.},
+  system. The paper also proposes a procedure to determine the optimal synchronous condenser ratings and locations to improve the overall system strength.}
 }
 
 @article{dong2019small,
@@ -1895,7 +1706,6 @@
   pages={1393-1403},
   doi={10.1109/TPWRS.2018.2875305},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The increasing penetration of renewable energy resources, such as wind and solar, is changing AC grid dynamics. Potential dynamic
   stability issues such as small signal instability may occur when these resources are connected to a grid with low strength, i.e., a weak grid.
   In this paper, the relationships between small signal stability and grid strength measured with short circuit ratio (SCR), along with the relationships
@@ -1905,7 +1715,7 @@
   representation of SCR and CSCR for SIPESs in MIPESs. The gSCR can assess the grid strength of a MIPES in terms of its small signal stability while
   the CgSCR can characterize the stability boundary of a MIPES. In addition, the condition of CgSCR = CSCR is satisfied for a MIPES with homogeneous
   power electronic devices. This enables the proposed method based on the gSCR to simplify the complex stability analysis of MIPESs into the stability
-  study of SIPESs. The efficacy of the proposed gSCR and CgSCR is validated with eigenvalue analysis and time-domain simulations.},
+  study of SIPESs. The efficacy of the proposed gSCR and CgSCR is validated with eigenvalue analysis and time-domain simulations.}
 }
 
 @article{li2025translating,
@@ -1919,7 +1729,6 @@
   year = {2025},
   doi = {10.1038/s44287-025-00210-5},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {The implementation of energy equity is a pivotal goal of the global energy transition, driven by widespread recognition of energy
   inequities worldwide. Energy equity has been broadly regarded as a sociological concept rather than an engineering one. The absence of technical
   engineering methods necessitates the development of a justified and sound approach to making energy equity an actionable practice in the broader realms
@@ -1927,7 +1736,7 @@
   of electric power systems. We look at policies for energy equity that have already been introduced in Europe and the USA, noting their limited effectiveness,
   and provide four categories of classification for current energy-equity research: quantifying energy equity, improving equity in the accessibility of
   electricity, improving equity in the affordability of electricity, and improving equity in the resilience of power systems. We then set out a roadmap to
-  address ongoing research challenges in energy equity.},
+  address ongoing research challenges in energy equity.}
 }
 
 @article{ieee2014std1547,
@@ -1949,7 +1758,7 @@
   to the electric power distribution system. This guide describes criteria, scope, and extent for those engineering studies. Study scope and
   extent are described as functions of identifiable characteristics of the DR, the EPS, and the interconnection. The intent includes promoting
   impact study consistency while helping identify only those studies that should be performed based on technically transparent criteria for the
-  DR interconnection.},
+  DR interconnection.}
 }
 
 @inproceedings{reno2017qsts,
@@ -1963,12 +1772,11 @@
   pages = {1-5},
   doi = {10.1109/PESGM.2017.8274703},
   dimensions = {true},
-  bibtex_show = {true},
   abstract = {Distribution system analysis with ever increasing numbers of distributed energy resources (DER) requires quasistatic time-series
   (QSTS) analysis to capture the time-varying and time-dependent aspects of the system. Previous literature has demonstrated the benefits of QSTS,
   but there is limited information available for the requirements and standards for performing QSTS simulations. This paper provides a novel
   analysis of the QSTS requirements for the input data timeresolution, the simulation time-step resolution, and the length of the simulation.
-  Detailed simulations quantify the specific errors introduced by not performing yearlong high-resolution QSTS simulations.},
+  Detailed simulations quantify the specific errors introduced by not performing yearlong high-resolution QSTS simulations.}
 }
 
 @book{milano2010power,
@@ -1982,7 +1790,6 @@
   publisher = {Springer Berlin Heidelberg},
   author = {Milano,  Federico},
   year = {2010},
-  bibtex_show = {true},
   abstract = {Power system modelling and scripting is a quite general and ambitious title. Of course, to embrace all existing aspects of power
   system modelling would lead to an encyclopedia and would be likely an impossible task. Thus, the book focuses on a subset of power system models
   based on the following assumptions: (i) devices are modelled as a set of nonlinear differential algebraic equations, (ii) all alternate-current
@@ -1991,7 +1798,7 @@
   is not self-sufficient. Mathematical models have to be translated into computer programming code in order to be analyzed, understood and
   “experienced”. It is an object of the book to provide a general framework for a power system analysis software tool and hints for filling up
   this framework with versatile programming code. This book is for all students and researchers that are looking for a quick reference on power
-  system models or need some guidelines for starting the challenging adventure of writing their own code.},
+  system models or need some guidelines for starting the challenging adventure of writing their own code.}
 }
 
 @inproceedings{kolesnikov2002synergetic,
@@ -2005,13 +1812,12 @@
   pages={409-415},
   doi={10.1109/APEC.2002.989278},
   dimensions={true},
-  bibtex_show={true},
   abstract={This paper describes a new approach to the synthesis of controllers for power converters based on the theory of synergetic
   control. The controller synthesis procedure is completely analytical, and is based on fully nonlinear models of the converter. Synergetic
   controllers provide asymptotic stability with respect to the required operating modes, invariance to load variations, and robustness to
   variation of converter parameters. With respect to their dynamic characteristics, synergetic controllers are superior to the existing
   types of PI controllers. We present here the theory of the approach, a synthesis example for a boost converter, simulation results,
-  and experimental results.},
+  and experimental results.}
 }
 
 @incollection{harden2025intelligence,
@@ -2023,7 +1829,7 @@
   publisher = {MIT Press},
   author = {Harden, K. Paige},
   year = {2025},
-  month = {August},
+  month = {August}
 }
 
 @article{gignac2024defining,
@@ -2039,7 +1845,6 @@
   year = {2024},
   month = may,
   pages = {101832},
-  bibtex_show = {true},
   dimensions = {true},
   abstract = {Achieving a widely accepted definition of human intelligence has been challenging, a situation mirrored by the diverse
   definitions of artificial intelligence in computer science. By critically examining published definitions, highlighting both consistencies
@@ -2054,7 +1859,7 @@
   a reflection of the shared variance in artificial system performances. We conclude that current evidence more greatly supports the
   observation of artificial achievement and expertise over artificial intelligence. However, interdisciplinary collaborations, based on
   common understandings of the nature of intelligence, as well as sound measurement practices, could facilitate scientific innovations
-  that help bridge the gap between artificial and human-like intelligence.},
+  that help bridge the gap between artificial and human-like intelligence.}
 }
 
 @online{fivable2024artificial,
@@ -2063,8 +1868,7 @@
   title  = {Artificial Intelligence -- Cognitive Psychology},
   editor = {Bahr, Becky},
   year   = {2024},
-  url    = {https://fiveable.me/key-terms/cognitive-psychology/artificial-intelligence},
-  bibtex_show = {true},
+  url    = {https://fiveable.me/key-terms/cognitive-psychology/artificial-intelligence}
 }
 
 @book{kahneman2011thinking,
@@ -2075,8 +1879,7 @@
   address = {New York, NY, USA},
   year = {2011},
   edition = {1st},
-  isbn = {9780374275631},
-  bibtex_show = {true},
+  isbn = {9780374275631}
 }
 
 @inproceedings{huang2023reasoning,
@@ -2092,7 +1895,6 @@
   url = {https://aclanthology.org/2023.findings-acl.67/},
   doi = {10.18653/v1/2023.findings-acl.67},
   pages = {1049--1065},
-  bibtex_show = {true},
   dimensions = {true},
   abstract = {Reasoning is a fundamental aspect of human intelligence that plays a crucial role in activities such as problem
   solving, decision making, and critical thinking. In recent years, large language models (LLMs) have made significant progress
@@ -2101,7 +1903,7 @@
   comprehensive overview of the current state of knowledge on reasoning in LLMs, including techniques for improving and eliciting
   reasoning in these models, methods and benchmarks for evaluating reasoning abilities, findings and implications of previous
   research in this field, and suggestions on future directions. Our aim is to provide a detailed and up-to-date review of this
-  topic and stimulate meaningful discussion and future work.},
+  topic and stimulate meaningful discussion and future work.}
 }
 
 @article{paulo2025smartgrid,
@@ -2117,7 +1919,6 @@
   number = {6},
   pages = {1845-1853},
   doi = {10.35833/MPCE.2025.000807},
-  bibtex_show = {true},
   dimensions = {true},
   abstract = {This paper captures an engaging—and at times heated—Power-Globe (PG) discussion of evolving definitions of smart grid
   technologies. The exchange took place between December 2024 and January 2025. The primary objective of this paper is to clarify some
@@ -2125,7 +1926,7 @@
   have sometimes been advocated as a panacea to resolve the tension between competing objectives for the provision of electricity
   (specifically, making it reliable, clean, and affordable). This paper examines the term “smart grid” in terms of raw technical
   functionalities, applications, and use cases, some of which may get closer than others to meeting the aspirational promises. While smart
-  technology should expand our menu of options, it will not absolve us of the need to make hard decisions.},
+  technology should expand our menu of options, it will not absolve us of the need to make hard decisions.}
 }
 
 @online{eisa2007,
@@ -2135,17 +1936,14 @@
   institution = {U.S. Government Publishing Office},
   year = {2007},
   month = {dec},
-  bibtex_show = {true},
-  url = {https://www.congress.gov/110/plaws/publ140/PLAW-110publ140.pdf},
-  pdf = {https://www.congress.gov/110/plaws/publ140/PLAW-110publ140.pdf},
+  url = {https://www.congress.gov/110/plaws/publ140/PLAW-110publ140.pdf}
 }
 
 @online{ec2025smartgrid,
   abbr = {Industry},
   title = {Smart grids and meters},
   url = {https://energy.ec.europa.eu/topics/markets-and-consumers/smart-grids-and-meters_en},
-  year = {2025},
-  bibtex_show = {true},
+  year = {2025}
 }
 
 @article{schweppe1970staticstate,
@@ -2158,13 +1956,12 @@
   number = {1},
   pages = {120-125},
   doi = {10.1109/TPAS.1970.292678},
-  bibtex_show = {true},
   dimensions = {true},
   abstract = {The static state of an electric power system is defined as the vector of the voltage magnitudes and angles at all network
   buses. The static-state estimator is a data processing algorithm far converting redundant meter readings and other available information
   into an estimate of the static-state vector. Discussions center on the general nature of the problem, mathematical modeling, an
   interative technique for calculating the state estimate, and concepts underlying the detection and identification of modeling errors.
-  Problems of interconnected systems are considered. Results of some initial computer simulation tests are discussed.},
+  Problems of interconnected systems are considered. Results of some initial computer simulation tests are discussed.}
 }
 
 @online{geocaris2022assessing,
@@ -2173,8 +1970,7 @@
   title = {Assessing Power System Reliability in a Changing Grid Environment},
   month = {August},
   year = {2022},
-  bibtex_show = {true},
-  url = {https://www.nrel.gov/news/detail/program/2022/assessing-power-system-reliability-in-a-changing-grid-environment},
+  url = {https://www.nrel.gov/news/detail/program/2022/assessing-power-system-reliability-in-a-changing-grid-environment}
 }
 
 @online{ferc2023reliability,
@@ -2183,8 +1979,7 @@
   url = {https://www.ferc.gov/reliability-explainer},
   day = {16},
   year = {2023},
-  month = {August},
-  bibtex_show = {true},
+  month = {August}
 }
 
 @online{gbt2022,
@@ -2195,8 +1990,7 @@
   year = {2022},
   day = {30},
   month = {12},
-  bibtex_show = {true},
-  language = {Chinese},
+  language = {Chinese}
 }
 
 @online{sun2021smallsignal,
@@ -2204,9 +1998,7 @@
   author = {Kai Sun},
   title = {ECE 522 - Power Systems Analysis II: Small-Signal Stability},
   year = {2021},
-  url = {https://web.eecs.utk.edu/~kaisun/ECE522/ECE522_7-Small-signalStability.pdf},
-  pdf = {https://web.eecs.utk.edu/~kaisun/ECE522/ECE522_7-Small-signalStability.pdf},
-  bibtex_show = {true},
+  url = {https://web.eecs.utk.edu/~kaisun/ECE522/ECE522_7-Small-signalStability.pdf}
 }
 
 @article{ieee1985terms,
@@ -2216,5 +2008,5 @@
   volume={PAS-104},
   number={6},
   pages={1326-1334},
-  doi={10.1109/TPAS.1985.319152},
+  doi={10.1109/TPAS.1985.319152}
 }

--- a/assets/bibliography/papers.bib
+++ b/assets/bibliography/papers.bib
@@ -154,6 +154,7 @@
   day = {16},
   url = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-1.pdf},
   pdf = {https://www.nerc.com/pa/Stand/Reliability%20Standards/BAL-001-1.pdf},
+  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. Superseded standard — BAL-001-2 remains active.},
 }
 
 @online{nerc2015bal001,
@@ -284,8 +285,9 @@
   title = {Ancillary Service and Balancing Authority Area Solutions to Integrate Variable Generation},
   year = {2011},
   month = {March},
-  url = {https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF2-3.pdf},
-  pdf = {https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF2-3.pdf},
+  url = {http://web.archive.org/web/20220605060008/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF2-3.pdf},
+  pdf = {http://web.archive.org/web/20220605060008/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF2-3.pdf},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2022-06-05).},
   bibtex_show = {true},
 }
 
@@ -460,8 +462,9 @@
   title = {Reliability Terminology},
   year = {2013},
   month = {August},
-  url = {https://www.nerc.com/AboutNERC/Documents/Terms%20AUG13.pdf},
-  pdf = {https://www.nerc.com/AboutNERC/Documents/Terms%20AUG13.pdf},
+  url = {http://web.archive.org/web/20250401183750/https://www.nerc.com/aboutnerc/documents/terms%20aug13.pdf},
+  pdf = {http://web.archive.org/web/20250401183750/https://www.nerc.com/aboutnerc/documents/terms%20aug13.pdf},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-04-01).},
   bibtex_show = {true},
 }
 
@@ -482,8 +485,9 @@
   title = {Special Report Potential Reliability Impacts of Emerging Flexible Resources},
   year = {2010},
   month = {November},
-  url = {https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF_Task_1_5_Final.pdf},
-  pdf = {https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF_Task_1_5_Final.pdf},
+  url = {http://web.archive.org/web/20250615132555/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF_Task_1_5_Final.pdf},
+  pdf = {http://web.archive.org/web/20250615132555/https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/IVGTF_Task_1_5_Final.pdf},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-06-15).},
   bibtex_show = {true},
 }
 
@@ -568,8 +572,9 @@
   year = {2015},
   month = {December},
   day = {12},
-  url = {https://site.ieee.org/pes-enews/2015/12/10/a-brief-history-the-common-information-model/},
-  html = {https://site.ieee.org/pes-enews/2015/12/10/a-brief-history-the-common-information-model/},
+  url = {http://web.archive.org/web/20220602142235/https://site.ieee.org/pes-enews/2015/12/10/a-brief-history-the-common-information-model/},
+  html = {http://web.archive.org/web/20220602142235/https://site.ieee.org/pes-enews/2015/12/10/a-brief-history-the-common-information-model/},
+  note = {Original IEEE PES eNews URL permanently gone (HTTP 410) as of 2026-05-27; archived via Wayback Machine (snapshot 2022-06-02).},
   bibtex_show = {true},
 }
 
@@ -808,8 +813,8 @@
   month = {November},
   day = {20},
   title = {Manuals M-3: Transmission Operations (Revision 69)},
-  url = {https://www.pjm.com/-/media/DotCom/documents/manuals/m03.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/m03.pdf},
+  url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v69-transmission-operations-11-20-2025.pdf},
+  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m03/m03v69-transmission-operations-11-20-2025.pdf},
   bibtex_show = {true},
   abstract = {The PJM Manual for Transmission Operations is one of a series of manuals within the
   Transmission set. This manual focuses on specific transmission conditions and procedures for
@@ -915,8 +920,8 @@
   year = {2024},
   month = {September},
   day = {25},
-  url = {https://www.pjm.com/-/media/DotCom/documents/manuals/m14b.pdf},
-  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/m14b.pdf},
+  url = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14b/m14bv57-pjm-region-transmission-planning-process-09-25-2024.pdf},
+  pdf = {https://www.pjm.com/-/media/DotCom/documents/manuals/archive/m14b/m14bv57-pjm-region-transmission-planning-process-09-25-2024.pdf},
   bibtex_show = {true},
   abstract = {The PJM Region Transmission Planning Process Manual is one of the PJM manuals in the
   PJM Regional Transmission Expansion group. This manual focuses on the process for planning
@@ -1185,6 +1190,7 @@
   day = {2},
   url = {https://www.nyiso.com/documents/20142/43891523/M-02-Ancillary-Services-Manual.pdf/653fb105-8b85-48b8-edcc-bc21f62a2ef9},
   pdf = {https://www.nyiso.com/documents/20142/43891523/M-02-Ancillary-Services-Manual.pdf/653fb105-8b85-48b8-edcc-bc21f62a2ef9},
+  note = {URL unavailable as of 2026-05-27; no Wayback Machine snapshot found. NYISO may have issued an updated version — check https://www.nyiso.com/manuals-tech-bulletins-user-guides for the current M-02 manual.},
   bibtex_show = {true},
 }
 
@@ -1284,8 +1290,9 @@
   title = {Frequently Asked Questions},
   year = {2023},
   month = {March},
-  url = {https://www.nerc.com/news/Documents/March%202023%20NERC%20Frequently%20Asked%20Questions%20FAQ.pdf},
-  pdf = {https://www.nerc.com/news/Documents/March%202023%20NERC%20Frequently%20Asked%20Questions%20FAQ.pdf},
+  url = {http://web.archive.org/web/20250829001613/https://www.nerc.com/news/Documents/March%202023%20NERC%20Frequently%20Asked%20Questions%20FAQ.pdf},
+  pdf = {http://web.archive.org/web/20250829001613/https://www.nerc.com/news/Documents/March%202023%20NERC%20Frequently%20Asked%20Questions%20FAQ.pdf},
+  note = {Original NERC URL unavailable as of 2026-05-27; archived via Wayback Machine (snapshot 2025-08-29).},
   bibtex_show = {true},
 }
 

--- a/database/json/control-performance-standard-2.json
+++ b/database/json/control-performance-standard-2.json
@@ -2,7 +2,7 @@
   "$schema": "https://ps-wiki.github.io/schema/v1/term.schema.json",
   "id": "control-performance-standard-2",
   "title": "Control Performance Standard 2",
-  "description": "CPS2. A standard intended to limit unscheduled flows.",
+  "description": "CPS2. Inactive. A standard intended to limit unscheduled flows.",
   "language": "en",
   "tags": [
     "frequency-control",
@@ -12,7 +12,7 @@
   "breaking": false,
   "dates": {
     "created": "2025-03-15",
-    "last_modified": "2025-06-20"
+    "last_modified": "2026-05-27"
   },
   "authors": [
     {
@@ -41,7 +41,7 @@
         "source_keys": [
           "nerc2015bal0011"
         ],
-        "page": "p3",
+        "page": null,
         "body_md": "$$\nCPS2 = \\left[ 1 - \\frac{\\text{Violations}_{\\text{month}}}{\\text{Total Periods}_{\\text{month}} - \\text{Unavailable Periods}_{\\text{month}}} \\right] \\times 100\n$$\n"
       }
     ]

--- a/database/pyscripts/check_references.py
+++ b/database/pyscripts/check_references.py
@@ -14,6 +14,7 @@ Usage:
 
 import argparse
 import json
+import re
 import sys
 import time
 import urllib.error
@@ -28,6 +29,9 @@ from bibtexparser.bparser import BibTexParser
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BIB = REPO_ROOT / "assets" / "bibliography" / "papers.bib"
 DEFAULT_OUT = REPO_ROOT / "database" / "build" / "reference_check.json"
+DEFAULT_WIKI_DIR = REPO_ROOT / "_wiki"
+
+_DCITE_RE = re.compile(r'<d-cite\b[^>]*key="([^"]*)"')
 
 URL_FIELDS = ("url", "pdf", "html")
 NERC_DOMAIN = "nerc.com"
@@ -75,6 +79,24 @@ def collect_urls(entries: list[dict]) -> list[dict]:
                 }
             )
     return records
+
+
+# ---------------------------------------------------------------------------
+# Wiki cross-reference
+# ---------------------------------------------------------------------------
+
+def find_citing_terms(key: str, wiki_dir: Path) -> list[str]:
+    """Return sorted _wiki/*.md relative paths that contain a <d-cite> for key."""
+    if not wiki_dir.exists():
+        return []
+    matches = []
+    for md_file in sorted(wiki_dir.glob("*.md")):
+        text = md_file.read_text(encoding="utf-8")
+        for m in _DCITE_RE.finditer(text):
+            if key in [k.strip() for k in m.group(1).split(",")]:
+                matches.append(f"_wiki/{md_file.name}")
+                break
+    return matches
 
 
 # ---------------------------------------------------------------------------
@@ -182,10 +204,13 @@ def scan(records: list[dict], recover: bool) -> list[dict]:
 # Reporting
 # ---------------------------------------------------------------------------
 
-def build_report(results: list[dict], bib_path: Path) -> dict:
+def build_report(
+    results: list[dict], bib_path: Path, wiki_dir: Path = DEFAULT_WIKI_DIR
+) -> dict:
     categories = {"ok": [], "redirect": [], "broken": [], "server_error": []}
     for r in results:
         categories.setdefault(r["category"], []).append(r)
+        r["used_by"] = find_citing_terms(r["key"], wiki_dir)
 
     return {
         "scanned_at": datetime.now(timezone.utc).isoformat(),
@@ -221,12 +246,13 @@ def print_summary(report: dict) -> None:
             return
         print(f"--- {label} ({len(items)}) ---")
         for r in items:
-            archive_note = f"  archive: {r['archive_url']}" if r.get("archive_url") else ""
             code_note = f" [{r['status_code']}]" if r["status_code"] else f" [{r['error']}]"
             print(f"  {r['key']} ({r['field']}){code_note}")
             print(f"    {r['url']}")
-            if archive_note:
-                print(f"    {archive_note}")
+            if r.get("archive_url"):
+                print(f"    archive: {r['archive_url']}")
+            if r.get("used_by"):
+                print(f"    used by: {', '.join(r['used_by'])}")
         print()
 
     _print_group("NERC broken", nerc_broken)
@@ -241,6 +267,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Check reference URLs in papers.bib")
     parser.add_argument("--bib", type=Path, default=DEFAULT_BIB)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--wiki-dir", type=Path, default=DEFAULT_WIKI_DIR,
+                        help="Path to _wiki/ directory for used-by lookup")
     parser.add_argument(
         "--recover",
         action="store_true",
@@ -262,7 +290,7 @@ def main() -> None:
     print("Scanning URLs ...")
     results = scan(records, recover=args.recover)
 
-    report = build_report(results, args.bib)
+    report = build_report(results, args.bib, wiki_dir=args.wiki_dir)
     args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
     print(f"\nReport written to {args.out}")
 

--- a/database/pyscripts/check_references.py
+++ b/database/pyscripts/check_references.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Reference URL health scanner for PS-Wiki.
+
+Parses assets/bibliography/papers.bib, checks every URL in the `url`, `pdf`,
+and `html` fields, and writes a structured report to database/build/reference_check.json.
+
+Usage:
+    python database/pyscripts/check_references.py
+    python database/pyscripts/check_references.py --recover   # also query Wayback Machine for broken NERC URLs
+    python database/pyscripts/check_references.py --bib path/to/custom.bib
+    python database/pyscripts/check_references.py --out path/to/output.json
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import bibtexparser
+from bibtexparser.bparser import BibTexParser
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_BIB = REPO_ROOT / "assets" / "bibliography" / "papers.bib"
+DEFAULT_OUT = REPO_ROOT / "database" / "build" / "reference_check.json"
+
+URL_FIELDS = ("url", "pdf", "html")
+NERC_DOMAIN = "nerc.com"
+REQUEST_DELAY = 0.5  # seconds between requests
+TIMEOUT = 12  # seconds
+WAYBACK_API = "https://archive.org/wayback/available?url={url}"
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (compatible; pswiki-refcheck/1.0; "
+        "+https://github.com/jinningwang/pswiki)"
+    )
+}
+
+
+# ---------------------------------------------------------------------------
+# BibTeX parsing
+# ---------------------------------------------------------------------------
+
+def load_bib(bib_path: Path) -> list[dict]:
+    parser = BibTexParser(common_strings=True)
+    parser.ignore_nonstandard_types = False
+    with open(bib_path, encoding="utf-8") as f:
+        db = bibtexparser.load(f, parser=parser)
+    return db.entries
+
+
+def collect_urls(entries: list[dict]) -> list[dict]:
+    """Return deduplicated list of {key, field, url, is_nerc}."""
+    seen: set[str] = set()
+    records = []
+    for entry in entries:
+        key = entry["ID"]
+        for field in URL_FIELDS:
+            url = entry.get(field, "").strip()
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            records.append(
+                {
+                    "key": key,
+                    "field": field,
+                    "url": url,
+                    "is_nerc": NERC_DOMAIN in url,
+                }
+            )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# HTTP checking
+# ---------------------------------------------------------------------------
+
+def _make_request(url: str, method: str = "HEAD") -> tuple[int, str]:
+    """Return (status_code, final_url). Raises urllib.error.URLError on failure."""
+    req = urllib.request.Request(url, headers=HEADERS, method=method)
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return resp.status, resp.url
+
+
+def check_url(url: str) -> dict:
+    """Check a single URL and return a status dict."""
+    result = {"status_code": None, "final_url": None, "error": None, "category": None}
+    try:
+        code, final = _make_request(url, method="HEAD")
+        if code == 405:
+            code, final = _make_request(url, method="GET")
+        result["status_code"] = code
+        result["final_url"] = final if final != url else None
+    except urllib.error.HTTPError as e:
+        if e.code == 405:
+            try:
+                code, final = _make_request(url, method="GET")
+                result["status_code"] = code
+                result["final_url"] = final if final != url else None
+            except urllib.error.HTTPError as e2:
+                result["status_code"] = e2.code
+                result["error"] = str(e2.reason)
+        else:
+            result["status_code"] = e.code
+            result["error"] = str(e.reason)
+    except urllib.error.URLError as e:
+        result["error"] = str(e.reason)
+    except TimeoutError:
+        result["error"] = "timeout"
+    except Exception as e:
+        result["error"] = str(e)
+
+    code = result["status_code"]
+    if code is None:
+        result["category"] = "broken"
+    elif 200 <= code < 300:
+        result["category"] = "ok"
+    elif 300 <= code < 400:
+        result["category"] = "redirect"
+    elif 400 <= code < 500:
+        result["category"] = "broken"
+    else:
+        result["category"] = "server_error"
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Wayback Machine recovery
+# ---------------------------------------------------------------------------
+
+def wayback_lookup(url: str) -> str | None:
+    """Return the most recent Wayback Machine snapshot URL, or None."""
+    api_url = WAYBACK_API.format(url=urllib.parse.quote(url, safe=":/?=&%"))
+    try:
+        req = urllib.request.Request(api_url, headers=HEADERS)
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            data = json.loads(resp.read())
+        snapshot = data.get("archived_snapshots", {}).get("closest", {})
+        if snapshot.get("available"):
+            return snapshot["url"]
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+def scan(records: list[dict], recover: bool) -> list[dict]:
+    total = len(records)
+    results = []
+    for i, rec in enumerate(records, 1):
+        url = rec["url"]
+        print(f"  [{i}/{total}] {url[:80]}", end="", flush=True)
+        check = check_url(url)
+        entry = {**rec, **check, "archive_url": None}
+
+        if recover and entry["is_nerc"] and entry["category"] in ("broken", "server_error"):
+            archive = wayback_lookup(url)
+            entry["archive_url"] = archive
+            time.sleep(REQUEST_DELAY)
+
+        print(f"  → {entry['category'].upper()}"
+              + (f" ({entry['status_code']})" if entry["status_code"] else "")
+              + (f"  [archive found]" if entry.get("archive_url") else ""))
+
+        results.append(entry)
+        time.sleep(REQUEST_DELAY)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def build_report(results: list[dict], bib_path: Path) -> dict:
+    categories = {"ok": [], "redirect": [], "broken": [], "server_error": []}
+    for r in results:
+        categories.setdefault(r["category"], []).append(r)
+
+    return {
+        "scanned_at": datetime.now(timezone.utc).isoformat(),
+        "bib_file": str(bib_path),
+        "summary": {cat: len(items) for cat, items in categories.items()},
+        "results": results,
+    }
+
+
+def print_summary(report: dict) -> None:
+    s = report["summary"]
+    total = sum(s.values())
+    print()
+    print("=" * 60)
+    print(f"Reference check complete — {report['scanned_at']}")
+    print(f"  Total URLs scanned : {total}")
+    print(f"  OK (2xx)           : {s.get('ok', 0)}")
+    print(f"  Redirect (3xx)     : {s.get('redirect', 0)}")
+    print(f"  Broken (4xx/conn)  : {s.get('broken', 0)}")
+    print(f"  Server error (5xx) : {s.get('server_error', 0)}")
+    print()
+
+    broken = [r for r in report["results"] if r["category"] in ("broken", "server_error")]
+    if not broken:
+        print("No broken links found.")
+        return
+
+    nerc_broken = [r for r in broken if r["is_nerc"]]
+    other_broken = [r for r in broken if not r["is_nerc"]]
+
+    def _print_group(label: str, items: list[dict]) -> None:
+        if not items:
+            return
+        print(f"--- {label} ({len(items)}) ---")
+        for r in items:
+            archive_note = f"  archive: {r['archive_url']}" if r.get("archive_url") else ""
+            code_note = f" [{r['status_code']}]" if r["status_code"] else f" [{r['error']}]"
+            print(f"  {r['key']} ({r['field']}){code_note}")
+            print(f"    {r['url']}")
+            if archive_note:
+                print(f"    {archive_note}")
+        print()
+
+    _print_group("NERC broken", nerc_broken)
+    _print_group("Other broken", other_broken)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check reference URLs in papers.bib")
+    parser.add_argument("--bib", type=Path, default=DEFAULT_BIB)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--recover",
+        action="store_true",
+        help="Query Wayback Machine for broken NERC URLs",
+    )
+    args = parser.parse_args()
+
+    if not args.bib.exists():
+        print(f"ERROR: bib file not found: {args.bib}", file=sys.stderr)
+        sys.exit(1)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Parsing {args.bib} ...")
+    entries = load_bib(args.bib)
+    records = collect_urls(entries)
+    print(f"Found {len(records)} unique URLs across {len(entries)} entries.\n")
+
+    print("Scanning URLs ...")
+    results = scan(records, recover=args.recover)
+
+    report = build_report(results, args.bib)
+    args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\nReport written to {args.out}")
+
+    print_summary(report)
+
+    broken_count = report["summary"].get("broken", 0) + report["summary"].get("server_error", 0)
+    sys.exit(1 if broken_count else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/database/pyscripts/check_references.py
+++ b/database/pyscripts/check_references.py
@@ -145,6 +145,8 @@ def check_url(url: str) -> dict:
         result["category"] = "ok"
     elif 300 <= code < 400:
         result["category"] = "redirect"
+    elif code == 403:
+        result["category"] = "server_error"  # bot-blocking indistinguishable from real 403
     elif 400 <= code < 500:
         result["category"] = "broken"
     else:

--- a/database/pyscripts/render_ref_issue.py
+++ b/database/pyscripts/render_ref_issue.py
@@ -46,9 +46,18 @@ def render_issue_body(
     all_results = report["results"]
 
     broken_results = [r for r in all_results if r["category"] in ("broken", "server_error")]
-    recoverable = [r for r in broken_results if r.get("archive_url")]
-    temporary = [r for r in broken_results if not r.get("archive_url") and r["category"] == "server_error"]
-    needs_review = [r for r in broken_results if not r.get("archive_url") and r["category"] == "broken"]
+    recoverable = sorted(
+        [r for r in broken_results if r.get("archive_url")],
+        key=lambda r: (not r.get("used_by"), r["key"]),
+    )
+    temporary = sorted(
+        [r for r in broken_results if not r.get("archive_url") and r["category"] == "server_error"],
+        key=lambda r: (not r.get("used_by"), r["key"]),
+    )
+    needs_review = sorted(
+        [r for r in broken_results if not r.get("archive_url") and r["category"] == "broken"],
+        key=lambda r: (not r.get("used_by"), r["key"]),
+    )
 
     broken_count = len(broken_results)
     status = "✅ All references OK" if broken_count == 0 else f"⚠️ {broken_count} broken link(s) detected"
@@ -108,7 +117,7 @@ def render_issue_body(
 
         if temporary:
             L += [
-                "#### Possibly temporary (5xx / timeout — recheck before acting)",
+                "#### Possibly temporary (5xx / 403 / timeout — recheck before acting)",
                 "",
                 "| Key | Field | Error | Involved terms |",
                 "|-----|-------|-------|----------------|",

--- a/database/pyscripts/render_ref_issue.py
+++ b/database/pyscripts/render_ref_issue.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Render the GitHub issue body for the [CI] Reference Health Tracker issue.
+
+Called by the check-references CI workflow after a scan; outputs markdown to stdout.
+
+Usage:
+    python database/pyscripts/render_ref_issue.py \
+        --report database/build/reference_check.json \
+        --artifact-url <url> \
+        --sha <sha> \
+        --trigger <schedule|push|workflow_dispatch> \
+        --run-url <url>
+"""
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _domain(r: dict) -> str:
+    if r.get("is_nerc"):
+        return "NERC"
+    key = r["key"].lower()
+    for name in ("nyiso", "pjm", "ieee", "ferc", "cigre"):
+        if name in key:
+            return name.upper()
+    return "Other"
+
+
+def render_issue_body(
+    report: dict,
+    artifact_url: str,
+    sha: str,
+    trigger: str,
+    run_url: str,
+) -> str:
+    scan_iso = report["scanned_at"]
+    scan_date = scan_iso[:10]
+    scan_dt = datetime.fromisoformat(scan_iso.replace("Z", "+00:00"))
+    expiry = (scan_dt + timedelta(days=90)).strftime("%Y-%m-%d")
+
+    summary = report["summary"]
+    total = sum(summary.values())
+    all_results = report["results"]
+
+    broken_results = [r for r in all_results if r["category"] in ("broken", "server_error")]
+    recoverable = [r for r in broken_results if r.get("archive_url")]
+    temporary = [r for r in broken_results if not r.get("archive_url") and r["category"] == "server_error"]
+    needs_review = [r for r in broken_results if not r.get("archive_url") and r["category"] == "broken"]
+
+    broken_count = len(broken_results)
+    status = "✅ All references OK" if broken_count == 0 else f"⚠️ {broken_count} broken link(s) detected"
+
+    trigger_label = {
+        "schedule": "quarterly schedule",
+        "push": "`papers.bib` push",
+        "workflow_dispatch": "manual trigger",
+    }.get(trigger, trigger)
+    sha_short = sha[:7] if sha else "unknown"
+
+    L = []  # output lines
+
+    L += [
+        f"## Reference Health — {scan_date}",
+        "",
+        f"> **{status}** · {total} URLs checked · triggered by {trigger_label} · commit `{sha_short}`",
+        "",
+    ]
+    if artifact_url:
+        L.append(f"**Artifact**: [reference_check.json]({artifact_url}) _(expires {expiry})_")
+    else:
+        L.append("**Artifact**: not available")
+    L += ["", "---", ""]
+
+    if not broken_results:
+        L.append("No broken references found. 🎉")
+    else:
+        L.append("### Broken references")
+        L.append("")
+
+        if recoverable:
+            L += [
+                "#### Recoverable — Wayback Machine snapshot found",
+                "",
+                "| Key | Field | Error | Involved terms | Suggested URL |",
+                "|-----|-------|-------|----------------|---------------|",
+            ]
+            for r in recoverable:
+                terms = ", ".join(f"`{t}`" for t in r.get("used_by", [])) or "—"
+                error = str(r.get("status_code") or r.get("error", ""))
+                L.append(f"| `{r['key']}` | `{r['field']}` | {error} | {terms} | `{r['archive_url']}` |")
+            L.append("")
+
+        if needs_review:
+            L += [
+                "#### Needs manual review",
+                "",
+                "| Key | Field | Error | Domain | Involved terms | Notes |",
+                "|-----|-------|-------|--------|----------------|-------|",
+            ]
+            for r in needs_review:
+                terms = ", ".join(f"`{t}`" for t in r.get("used_by", [])) or "—"
+                error = str(r.get("status_code") or r.get("error", ""))
+                L.append(f"| `{r['key']}` | `{r['field']}` | {error} | {_domain(r)} | {terms} | No archive found. |")
+            L.append("")
+
+        if temporary:
+            L += [
+                "#### Possibly temporary (5xx / timeout — recheck before acting)",
+                "",
+                "| Key | Field | Error | Involved terms |",
+                "|-----|-------|-------|----------------|",
+            ]
+            for r in temporary:
+                terms = ", ".join(f"`{t}`" for t in r.get("used_by", [])) or "—"
+                error = str(r.get("status_code") or r.get("error", ""))
+                L.append(f"| `{r['key']}` | `{r['field']}` | {error} | {terms} |")
+            L.append("")
+
+    L += [
+        "---",
+        "",
+        "### Fix guidance",
+        "",
+        "See [BibTeX URL conventions](.claude/AGENT.md#bibtex-url-conventions) in AGENT.md for",
+        "domain-specific strategies (NERC, NYISO, PJM, general).",
+        "",
+        "To apply fixes with agent assistance, run the `/fix-broken-refs` skill in Claude Code.",
+        "",
+        "---",
+        "",
+    ]
+
+    agent_data = {
+        "scan_date": scan_date,
+        "artifact_url": artifact_url or "",
+        "run_url": run_url or "",
+        "summary": {
+            "total_urls": total,
+            "broken": len(needs_review),
+            "recoverable": len(recoverable),
+            "temporary": len(temporary),
+        },
+        "broken": [
+            {
+                "key": r["key"],
+                "field": r["field"],
+                "current_url": r["url"],
+                "error": str(r.get("status_code") or r.get("error", "")),
+                "domain": _domain(r).lower(),
+                "wayback_url": r.get("archive_url"),
+                "used_by": r.get("used_by", []),
+            }
+            for r in recoverable + needs_review
+        ],
+        "temporary": [
+            {
+                "key": r["key"],
+                "field": r["field"],
+                "current_url": r["url"],
+                "error": str(r.get("status_code") or r.get("error", "")),
+                "used_by": r.get("used_by", []),
+            }
+            for r in temporary
+        ],
+    }
+
+    L += [
+        "<details>",
+        "<summary>Agent instructions (JSON)</summary>",
+        "",
+        "```json",
+        json.dumps(agent_data, indent=2),
+        "```",
+        "",
+        "</details>",
+    ]
+
+    return "\n".join(L)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render issue body for reference health tracker")
+    parser.add_argument("--report", type=Path, required=True, help="Path to reference_check.json")
+    parser.add_argument("--artifact-url", default="", metavar="URL")
+    parser.add_argument("--sha", default="", metavar="SHA")
+    parser.add_argument("--trigger", default="", metavar="EVENT")
+    parser.add_argument("--run-url", default="", metavar="URL")
+    args = parser.parse_args()
+
+    report = json.loads(args.report.read_text(encoding="utf-8"))
+    print(render_issue_body(report, args.artifact_url, args.sha, args.trigger, args.run_url))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,15 +9,16 @@ This page records major changes in this wiki.
 
 ### 05-27
 
-- Added reference URL health scanner (`python pswiki.py check-refs`) — checks all citation URLs in `papers.bib` for broken links, with optional Wayback Machine recovery for NERC entries
+- Added reference URL health scanner (`python pswiki.py check-refs`) — checks all citation URLs in `papers.bib` for broken links, with optional Wayback Machine recovery for NERC entries; reduced false positives by reclassifying HTTP 403 (bot-blocking CDNs) as temporary rather than broken
 - Added quarterly CI workflow for automated reference health scanning; results are surfaced in a persistent GitHub Issue
 - Fixed 7 broken citations in `papers.bib`: 5 NERC URLs replaced with Wayback Machine archive snapshots, 2 PJM manual entries pinned from floating current-doc URLs to versioned archive paths
+- Sanitized `papers.bib`: removed al-folio display fields (`pdf`, `html`, `bibtex_show`) no longer used by MkDocs renderer
 - Removed per-term `version` field; term pages now show last-modified date only (`version` no longer appears in `/v1/terms/{id}` API responses)
 - Fixed edit-page button to link to the correct GitHub repo (`ps-wiki.github.io`) and source file (`_wiki/<id>.md`)
 - Added MCP Server documentation page
 - Completed Jekyll/al-folio cleanup: removed Docker configs, Ruby plugins, 9 stale CI workflows, and `_config.yml` (repo is now Python-only)
 - Consolidated Python dependencies into `requirements-dev.txt` at repo root
-- Added `pswiki.py` centralized CLI — all developer workflows (`new`, `process`, `validate`, `serve`, `build`) go through one entry point
+- Added `pswiki.py` centralized CLI — all developer workflows (`new`, `process`, `validate`, `serve`, `build`, `check-refs`) go through one entry point
 
 ### 05-26
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ This page records major changes in this wiki.
 
 ### 05-27
 
+- Added reference URL health scanner (`python pswiki.py check-refs`) — checks all citation URLs in `papers.bib` for broken links, with optional Wayback Machine recovery for NERC entries
+- Added quarterly CI workflow for automated reference health scanning; results are surfaced in a persistent GitHub Issue
+- Fixed 7 broken citations in `papers.bib`: 5 NERC URLs replaced with Wayback Machine archive snapshots, 2 PJM manual entries pinned from floating current-doc URLs to versioned archive paths
 - Removed per-term `version` field; term pages now show last-modified date only (`version` no longer appears in `/v1/terms/{id}` API responses)
 - Fixed edit-page button to link to the correct GitHub repo (`ps-wiki.github.io`) and source file (`_wiki/<id>.md`)
 - Added MCP Server documentation page

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,6 +48,8 @@ python pswiki.py process              # process all terms
 python pswiki.py validate             # validate all term JSON files
 python pswiki.py serve                # local preview at http://localhost:8000
 python pswiki.py build                # production build (mkdocs --strict)
+python pswiki.py check-refs           # scan papers.bib for broken URLs
+python pswiki.py check-refs --recover # also query Wayback Machine for broken NERC URLs
 ```
 
 Install Python dependencies before first use:

--- a/pswiki.py
+++ b/pswiki.py
@@ -8,6 +8,8 @@ Usage:
     python pswiki.py validate [<id> ...]  Validate JSON against schema
     python pswiki.py serve                Build and serve site locally
     python pswiki.py build                Production build (mkdocs --strict)
+    python pswiki.py check-refs           Check bibliography URLs for broken links
+    python pswiki.py check-refs --recover Also query Wayback Machine for broken NERC URLs
 """
 
 import argparse
@@ -131,6 +133,40 @@ def _cmd_build(args: argparse.Namespace) -> None:
     cmd_build()
 
 
+def _cmd_check_refs(args: argparse.Namespace) -> None:
+    from check_references import (
+        build_report,
+        collect_urls,
+        load_bib,
+        print_summary,
+        scan,
+    )
+
+    bib_path = Path(args.bib) if args.bib else _REPO_ROOT / "assets" / "bibliography" / "papers.bib"
+    out_path = Path(args.out) if args.out else _REPO_ROOT / "database" / "build" / "reference_check.json"
+
+    print(f"Parsing {bib_path} ...")
+    entries = load_bib(bib_path)
+    records = collect_urls(entries)
+    print(f"Found {len(records)} unique URLs across {len(entries)} entries.\n")
+
+    print("Scanning URLs ...")
+    results = scan(records, recover=args.recover)
+
+    import json
+
+    report = build_report(results, bib_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\nReport written to {out_path}")
+
+    print_summary(report)
+
+    broken = report["summary"].get("broken", 0) + report["summary"].get("server_error", 0)
+    if broken:
+        sys.exit(1)
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -149,6 +185,8 @@ def _build_parser() -> argparse.ArgumentParser:
             "  python pswiki.py validate\n"
             "  python pswiki.py serve\n"
             "  python pswiki.py build\n"
+            "  python pswiki.py check-refs\n"
+            "  python pswiki.py check-refs --recover\n"
         ),
     )
 
@@ -194,6 +232,20 @@ def _build_parser() -> argparse.ArgumentParser:
         "build", help="Production build (mkdocs build --strict)"
     )
     p_build.set_defaults(func=_cmd_build)
+
+    # check-refs
+    p_chk = sub.add_parser(
+        "check-refs",
+        help="Check bibliography URLs for broken links",
+    )
+    p_chk.add_argument(
+        "--recover",
+        action="store_true",
+        help="Query Wayback Machine for broken NERC URLs",
+    )
+    p_chk.add_argument("--bib", metavar="PATH", help="Path to .bib file (default: papers.bib)")
+    p_chk.add_argument("--out", metavar="PATH", help="Path for JSON report (default: database/build/reference_check.json)")
+    p_chk.set_defaults(func=_cmd_check_refs)
 
     return parser
 


### PR DESCRIPTION
## Summary

- **Reference URL scanner** (`python pswiki.py check-refs`) — scans all `papers.bib` URLs for broken links, with optional Wayback Machine recovery for NERC entries; reclassifies HTTP 403 as "possibly temporary" to avoid false positives from bot-blocking CDNs (PJM, DOI resolvers)
- **Quarterly CI workflow** (`.github/workflows/check-references.yml`) — runs on schedule and on `papers.bib` push; surfaces results in a persistent GitHub Issue ([#37](https://github.com/ps-wiki/ps-wiki.github.io/issues/37)) with structured agent instructions block
- **`papers.bib` fixes** — resolved 7 broken citations (5 NERC → Wayback Machine archives, 2 PJM floating → versioned archive paths); fixed 2 ESIG entries with ephemeral query params; updated `nerc2015bal0011` to NERCipedia archive; fixed `nerc2013terminology` with Wayback Machine snapshot
- **`papers.bib` sanitization** — removed al-folio display fields (`pdf`, `html`, `bibtex_show`) no longer used by the MkDocs renderer
- **Term updates** — CPS2 description updated (marked Inactive, stale danger block removed); operating-reserve reference updated
- **Docs** — `check-refs` added to Developer CLI section in `docs/development.md`; changelog updated

Closes #11
Closes #37

## Test plan

- [ ] Confirm CI workflow triggers on merge (push to `main` touching `papers.bib`)
- [ ] Verify `reference_check.json` artifact is uploaded and downloadable from the Actions run
- [ ] Verify tracking issue body is updated and a comment is posted with the run link
- [ ] Spot-check that PJM and DOI URLs no longer appear in the "broken" table (should be "possibly temporary" or absent)
- [ ] Run `python pswiki.py check-refs` locally and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)